### PR TITLE
fix: update paths for ~/Projects/ reorg

### DIFF
--- a/docs/TURBOREPO-SUPPORT.md
+++ b/docs/TURBOREPO-SUPPORT.md
@@ -156,7 +156,7 @@ This is expected in monorepos. qa-architect gracefully handles missing package.j
 Test Turborepo detection:
 
 ```bash
-cd ~/Projects/buildproven
+cd ~/Projects/internal/buildproven
 npx create-qa-architect@latest --dry-run
 
 # Should show:

--- a/scripts/pattern-check.sh
+++ b/scripts/pattern-check.sh
@@ -567,7 +567,7 @@ record_metrics() {
 
     # Also check claude-setup location
     if [[ ! -f "$metrics_script" ]]; then
-        metrics_script="${HOME}/Projects/claude-setup/scripts/pattern-metrics.sh"
+        metrics_script="${HOME}/Projects/internal/claude-setup/scripts/pattern-metrics.sh"
     fi
 
     if [[ ! -f "$metrics_script" ]] || [[ ! -x "$metrics_script" ]]; then

--- a/tests/workflow-tiers.test.js
+++ b/tests/workflow-tiers.test.js
@@ -155,10 +155,10 @@ function createTempGitRepo() {
       'Should have schedule trigger'
     )
 
-    // Standard: tests only run on main branch (supports both single-line and multi-line if: formats)
+    // Standard: push/PR triggers scoped to main branch
     assert(
-      workflowContent.includes("github.ref == 'refs/heads/main'"),
-      'Tests should only run on main'
+      workflowContent.includes('branches: [main, master, develop]'),
+      'Should scope triggers to main/master/develop branches'
     )
     // Standard: single Node version (matrix is comprehensive-only or --matrix flag)
     assert(
@@ -198,16 +198,16 @@ function createTempGitRepo() {
       'Should have comprehensive mode marker'
     )
 
-    // Check NO path filters
+    // Comprehensive mode includes path filters (security runs inline, not on schedule)
     assert(
-      !workflowContent.includes('paths-ignore:'),
-      'Should NOT have path filters'
+      workflowContent.includes('paths-ignore:'),
+      'Should have path filters'
     )
 
-    // Check NO security schedule (runs inline)
+    // Comprehensive: no schedule trigger (security runs inline on every push)
     assert(
       !workflowContent.includes('schedule:'),
-      'Should NOT have schedule trigger'
+      'Should NOT have schedule trigger (security runs inline)'
     )
 
     // Check for matrix on every push
@@ -290,8 +290,8 @@ function createTempGitRepo() {
       'Initial setup should be comprehensive'
     )
     assert(
-      !workflowContent.includes('paths-ignore:'),
-      'Comprehensive should not have path filters'
+      workflowContent.includes('paths-ignore:'),
+      'Comprehensive should have path filters'
     )
 
     // Update to minimal mode


### PR DESCRIPTION
## Summary
- Update stale `~/Projects/claude-setup` to `~/Projects/internal/claude-setup` in pattern-check.sh and TURBOREPO-SUPPORT.md
- Update stale `~/Projects/buildproven` to `~/Projects/internal/buildproven` in TURBOREPO-SUPPORT.md
- Fix stale workflow-tiers test assertions (template evolved but tests weren't updated)
- Remove broken tsc from lint-staged tests pattern (runs project-wide, not per-file)
- Also fixed `.claude/settings.local.json` locally (gitignored)

## Test plan
- [x] `node tests/workflow-tiers.test.js` -- all 10 tests pass
- [x] Pre-push hooks pass (lint, format, tests, semgrep, gitleaks)