### PR TITLE
chore: release v5.13.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.1] - 2026-04-02
+
+### Fixed
+
+- **Comprehensive consumer workflow generation** now removes `paths-ignore` consistently, so generated comprehensive CI matches the intended full-coverage contract.
+- **Workflow tier regression coverage** now asserts the comprehensive-mode contract correctly in both consumer and tier tests.
+
 ## [5.13.0] - 2026-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.2] - 2026-04-02
+
+### Fixed
+
+- **GitHub trusted publishing release path** now publishes without `NPM_TOKEN`, allowing the configured npm trusted publisher for `buildproven/qa-architect` to handle release auth via OIDC.
+
 ## [5.13.1] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.3] - 2026-04-02
+
+### Fixed
+
+- **License path hardening now applies to writes as well as reads**, preventing `QAA_LICENSE_DIR` from redirecting local license and usage files outside the validated home/temp sandbox.
+- **Plain `--update` now preserves existing matrix workflows** while still allowing explicit tier switches to return to single-node CI when requested.
+- **Generated `security:audit` and `validate:pre-push` scripts now fail correctly** instead of masking earlier errors through shell operator precedence.
+- **Standard workflow documentation now matches runtime behavior**, describing main-branch single-node tests instead of a default matrix.
+
 ## [5.13.2] - 2026-04-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**npm**: `create-qa-architect` | **Version**: 5.13.0
+**npm**: `create-qa-architect` | **Version**: 5.13.1
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**npm**: `create-qa-architect` | **Version**: 5.13.1
+**npm**: `create-qa-architect` | **Version**: 5.13.2
 
 ## Project Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,4 +303,4 @@ For project-specific questions, see `CLAUDE.md` for development notes.
 
 ---
 
-> **Vibe Build Lab LLC (d/b/a BuildProven)** · [buildproven.ai](https://buildproven.ai)
+> **BuildProven** · [buildproven.ai](https://buildproven.ai)

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 VIBE BUILD LAB COMMERCIAL LICENSE
 
-Copyright (c) 2025 Vibe Build Lab LLC. All rights reserved.
+Copyright (c) 2025 BuildProven. All rights reserved.
 
 COMMERCIAL SOFTWARE - FREEMIUM MODEL
 
 This software and associated documentation files (the "Software") are
-proprietary commercial products of Vibe Build Lab LLC.
+proprietary commercial products of BuildProven.
 
 TERMS OF USE:
 
@@ -62,5 +62,5 @@ For licensing inquiries: support@buildproven.ai
 
 ---
 
-Vibe Build Lab LLC (d/b/a BuildProven)
+BuildProven
 https://buildproven.ai

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Quality automation CLI for JavaScript/TypeScript, Python, and shell script proje
 ---
 
 > **Maintainer & Ownership**
-> This project is maintained by **Vibe Build Lab LLC (d/b/a BuildProven)**, a studio focused on AI-assisted product development, micro-SaaS, and "vibe coding" workflows for solo founders and small teams.
+> This project is maintained by **BuildProven**, a studio focused on AI-assisted product development, micro-SaaS, and "vibe coding" workflows for solo founders and small teams.
 > Learn more at **https://buildproven.ai**.
 
 ---
@@ -158,7 +158,7 @@ npx create-qa-architect@latest --workflow-minimal
 
 **Best for:** Small teams, client projects, production apps
 
-- Matrix testing (Node 20 + 22) **only on main branch**
+- Single Node 22 testing **only on main branch**
 - Security scans run monthly
 - Path filters enabled
 - **Runtime:** ~15-20 min/commit
@@ -275,6 +275,8 @@ npx create-qa-architect@latest --update
 npm install
 npm run lint
 ```
+
+`--update` refreshes the existing `quality.yml` from the latest template while preserving the detected workflow tier and existing matrix setting unless you explicitly override the tier with `--workflow-minimal`, `--workflow-standard`, or `--workflow-comprehensive`.
 
 ### Dependency Monitoring (Free)
 
@@ -453,4 +455,4 @@ Commercial freemium license — the base CLI is free to use; Pro features requir
 
 ---
 
-> **Vibe Build Lab LLC (d/b/a BuildProven)** · [buildproven.ai](https://buildproven.ai)
+> **BuildProven** · [buildproven.ai](https://buildproven.ai)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,4 +55,4 @@ We follow responsible disclosure practices:
 
 ---
 
-> **Vibe Build Lab LLC (d/b/a BuildProven)** · [buildproven.ai](https://buildproven.ai)
+> **BuildProven** · [buildproven.ai](https://buildproven.ai)

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -19,7 +19,7 @@ const baseScripts = {
   'test:coverage': 'vitest run --coverage',
   'test:changed': 'vitest run --changed HEAD~1 --passWithNoTests',
   'security:audit':
-    '[ -f pnpm-lock.yaml ] && pnpm audit --audit-level high || [ -f yarn.lock ] && yarn audit || npm audit --audit-level high',
+    'if [ -f pnpm-lock.yaml ]; then pnpm audit --audit-level high; elif [ -f yarn.lock ]; then yarn audit; else npm audit --audit-level high; fi',
   'security:secrets':
     "node -e \"const fs=require('fs');const content=fs.readFileSync('package.json','utf8');if(/[\\\"\\'][a-zA-Z0-9+/]{20,}[\\\"\\']/.test(content)){console.error('❌ Potential hardcoded secrets in package.json');process.exit(1)}else{console.log('✅ No secrets detected in package.json')}\"",
   'security:config': 'npx create-qa-architect@latest --security-config',
@@ -28,8 +28,7 @@ const baseScripts = {
   'validate:docs': 'npx create-qa-architect@latest --validate-docs',
   'validate:comprehensive': 'npx create-qa-architect@latest --comprehensive',
   'validate:all': 'npm run validate:comprehensive && npm run security:audit',
-  'validate:pre-push':
-    'npm run test:patterns --if-present && npm run test:commands --if-present && npm run test:changed --if-present || npm test --if-present',
+  'validate:pre-push': `npm run test:patterns --if-present && npm run test:commands --if-present && if node -e "const pkg=require('./package.json');process.exit(pkg.scripts&&pkg.scripts['test:changed']?0:1)" 2>/dev/null; then npm run test:changed; else npm test --if-present; fi`,
 }
 
 const normalizeStylelintTargets = stylelintTargets => {

--- a/docs/dev_guide/CONVENTIONS.md
+++ b/docs/dev_guide/CONVENTIONS.md
@@ -11,7 +11,7 @@ QA Architect (`create-qa-architect`) is a CLI tool that bootstraps quality autom
 
 **Entry point:** `setup.js` — CLI argument parsing and orchestration. Run as `npx create-qa-architect` or `node setup.js`.
 
-**npm package:** `create-qa-architect` v5.13.1 (published via GitHub trusted publishing)
+**npm package:** `create-qa-architect` v5.13.2 (published via GitHub trusted publishing)
 
 ## Directory Structure
 

--- a/docs/dev_guide/CONVENTIONS.md
+++ b/docs/dev_guide/CONVENTIONS.md
@@ -11,7 +11,7 @@ QA Architect (`create-qa-architect`) is a CLI tool that bootstraps quality autom
 
 **Entry point:** `setup.js` — CLI argument parsing and orchestration. Run as `npx create-qa-architect` or `node setup.js`.
 
-**npm package:** `create-qa-architect` v5.13.0 (published via GitHub trusted publishing)
+**npm package:** `create-qa-architect` v5.13.1 (published via GitHub trusted publishing)
 
 ## Directory Structure
 

--- a/lib/license-validator.js
+++ b/lib/license-validator.js
@@ -691,4 +691,4 @@ class LicenseValidator {
   }
 }
 
-module.exports = { LicenseValidator }
+module.exports = { LicenseValidator, validateLicenseDir }

--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -16,15 +16,16 @@ const {
   verifyPayload,
   loadKeyFromEnv,
 } = require('./license-signing')
+const { validateLicenseDir } = require('./license-validator')
 
 // License storage locations
 // Support environment variable override for testing (like telemetry/error-reporter)
 // Use getter functions to allow env override before module load
 function getLicenseDir() {
-  return (
+  const requestedDir =
     process.env.QAA_LICENSE_DIR ||
     path.join(os.homedir(), '.create-qa-architect')
-  )
+  return validateLicenseDir(requestedDir)
 }
 
 function getLicenseFile() {
@@ -586,10 +587,7 @@ async function addLegitimateKey(
     }
 
     const normalizedKey = normalizeLicenseKey(licenseKey)
-    // Use the same license directory as the CLI
-    const licenseDir =
-      process.env.QAA_LICENSE_DIR ||
-      path.join(os.homedir(), '.create-qa-architect')
+    const licenseDir = getLicenseDir()
     const legitimateDBFile = path.join(licenseDir, 'legitimate-licenses.json')
     const privateKey = loadKeyFromEnv(
       process.env.LICENSE_REGISTRY_PRIVATE_KEY,

--- a/lib/workflow-config.js
+++ b/lib/workflow-config.js
@@ -66,6 +66,37 @@ function detectExistingWorkflowMode(projectPath) {
 }
 
 /**
+ * Detect whether matrix testing is enabled in an existing workflow.
+ * @param {string} projectPath - Path to project
+ * @returns {boolean} True when matrix testing is enabled
+ */
+function detectExistingMatrix(projectPath) {
+  const workflowPath = path.join(
+    projectPath,
+    '.github',
+    'workflows',
+    'quality.yml'
+  )
+
+  if (!fs.existsSync(workflowPath)) {
+    return false
+  }
+
+  try {
+    const content = fs.readFileSync(workflowPath, 'utf8')
+    return (
+      content.includes('# MATRIX_ENABLED: true') ||
+      content.includes('node-version: [20, 22]')
+    )
+  } catch (error) {
+    console.warn(
+      `⚠️  Could not detect existing matrix configuration: ${error.message}`
+    )
+    return false
+  }
+}
+
+/**
  * Strip a named section from workflow content.
  * Removes everything between # {{NAME_BEGIN}} and # {{NAME_END}} markers (inclusive).
  * Leaves a single newline to avoid collapsing adjacent YAML blocks.
@@ -136,6 +167,39 @@ function removeTriggerPathsIgnore(content, triggerName) {
 }
 
 /**
+ * Restrict the tests job to main branch pushes in standard mode.
+ * @param {string} content - Workflow content
+ * @returns {string} Updated content
+ */
+function addStandardTestsBranchGate(content) {
+  const lines = content.split('\n')
+  const output = []
+  let inTestsJob = false
+  let branchGateInserted = false
+
+  for (const line of lines) {
+    if (line === '  tests:') {
+      inTestsJob = true
+    } else if (
+      inTestsJob &&
+      line.startsWith('  ') &&
+      !line.startsWith('    ')
+    ) {
+      inTestsJob = false
+    }
+
+    output.push(line)
+
+    if (inTestsJob && line === '    if: |' && !branchGateInserted) {
+      output.push("      github.ref == 'refs/heads/main' &&")
+      branchGateInserted = true
+    }
+  }
+
+  return output.join('\n')
+}
+
+/**
  * Inject workflow mode-specific configuration into quality.yml
  * Uses section markers (# {{SECTION_BEGIN/END}}) for reliable content removal
  * instead of fragile structural regex patterns.
@@ -162,19 +226,13 @@ function injectWorkflowMode(workflowContent, mode) {
 
   // Mode-specific transformations
   if (mode === 'standard') {
-    // Standard: Add main branch condition to tests job
+    // Standard: run tests on main only to keep CI costs bounded.
     if (
-      updated.includes('tests:') &&
-      updated.includes('fromJSON(needs.detect-maturity.outputs.test-count)')
+      updated.includes('  tests:') &&
+      updated.includes('    if: |') &&
+      !updated.includes("github.ref == 'refs/heads/main'")
     ) {
-      updated = updated.replace(
-        /(tests:\s+runs-on:[^\n]+\s+needs:[^\n]+\s+if: \|\s*\n\s+)fromJSON\(needs\.detect-maturity\.outputs\.test-count\)/,
-        "$1github.ref == 'refs/heads/main' &&\n      fromJSON(needs.detect-maturity.outputs.test-count)"
-      )
-      updated = updated.replace(
-        /(\s+tests:\s+runs-on:[^\n]+\s+needs:[^\n]+\s+)if: fromJSON\(needs\.detect-maturity\.outputs\.test-count\) > 0/,
-        "$1if: github.ref == 'refs/heads/main' && fromJSON(needs.detect-maturity.outputs.test-count) > 0"
-      )
+      updated = addStandardTestsBranchGate(updated)
     }
   } else if (mode === 'comprehensive') {
     // Comprehensive: Remove paths-ignore blocks
@@ -284,6 +342,7 @@ function injectMatrix(workflowContent, enableMatrix) {
 
 module.exports = {
   detectExistingWorkflowMode,
+  detectExistingMatrix,
   injectWorkflowMode,
   injectMatrix,
   stripSection,

--- a/lib/workflow-config.js
+++ b/lib/workflow-config.js
@@ -86,6 +86,56 @@ function stripSection(content, sectionName) {
 }
 
 /**
+ * Remove a paths-ignore block from a top-level workflow trigger.
+ * @param {string} content - Workflow content
+ * @param {string} triggerName - Trigger key (e.g. push, pull_request)
+ * @returns {string} Updated content
+ */
+function removeTriggerPathsIgnore(content, triggerName) {
+  const lines = content.split('\n')
+  const output = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    output.push(line)
+
+    if (
+      line !== `  ${triggerName}:` &&
+      !line.startsWith(`  ${triggerName}: `)
+    ) {
+      continue
+    }
+
+    let scanIndex = index + 1
+    while (scanIndex < lines.length) {
+      const nextLine = lines[scanIndex]
+
+      if (nextLine.startsWith('  ') && !nextLine.startsWith('    ')) {
+        break
+      }
+
+      if (nextLine === '    paths-ignore:') {
+        scanIndex += 1
+        while (
+          scanIndex < lines.length &&
+          lines[scanIndex].startsWith('      - ')
+        ) {
+          scanIndex += 1
+        }
+        index = scanIndex - 1
+        break
+      }
+
+      output.push(nextLine)
+      index = scanIndex
+      scanIndex += 1
+    }
+  }
+
+  return output.join('\n')
+}
+
+/**
  * Inject workflow mode-specific configuration into quality.yml
  * Uses section markers (# {{SECTION_BEGIN/END}}) for reliable content removal
  * instead of fragile structural regex patterns.
@@ -128,14 +178,8 @@ function injectWorkflowMode(workflowContent, mode) {
     }
   } else if (mode === 'comprehensive') {
     // Comprehensive: Remove paths-ignore blocks
-    updated = updated.replace(
-      /(\s+push:\s+branches:[^\n]+)\s+paths-ignore:\s+- '\*\*\.md'\s+- 'docs\/\*\*'\s+- 'LICENSE'\s+- '\.gitignore'\s+- '\.editorconfig'/g,
-      '$1'
-    )
-    updated = updated.replace(
-      /(\s+pull_request:\s+branches:[^\n]+)\s+paths-ignore:\s+- '\*\*\.md'\s+- 'docs\/\*\*'\s+- 'LICENSE'\s+- '\.gitignore'\s+- '\.editorconfig'/g,
-      '$1'
-    )
+    updated = removeTriggerPathsIgnore(updated, 'push')
+    updated = removeTriggerPathsIgnore(updated, 'pull_request')
     // Comprehensive: Remove schedule trigger (security runs inline)
     updated = updated.replace(/\s+schedule:\s+- cron:[^\n]+[^\n]*\n?/g, '\n')
     // Comprehensive: Remove schedule condition from security job

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-qa-architect",
-      "version": "5.13.0",
+      "version": "5.13.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@npmcli/package-json": "^7.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-qa-architect",
-      "version": "5.13.1",
+      "version": "5.13.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@npmcli/package-json": "^7.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-qa-architect",
-      "version": "5.13.2",
+      "version": "5.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@npmcli/package-json": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "description": "QA Architect - Bootstrap quality automation for JavaScript/TypeScript and Python projects with GitHub Actions, pre-commit hooks, linting, formatting, and smart test strategy",
   "main": "setup.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "description": "QA Architect - Bootstrap quality automation for JavaScript/TypeScript and Python projects with GitHub Actions, pre-commit hooks, linting, formatting, and smart test strategy",
   "main": "setup.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "description": "QA Architect - Bootstrap quality automation for JavaScript/TypeScript and Python projects with GitHub Actions, pre-commit hooks, linting, formatting, and smart test strategy",
   "main": "setup.js",
   "bin": {
-    "create-qa-architect": "./setup.js"
+    "create-qa-architect": "setup.js"
   },
   "scripts": {
     "prepare": "[ \"$CI\" = \"true\" ] && echo 'Skipping Husky in CI' || husky",
@@ -80,7 +80,7 @@
     "dependency-monitoring",
     "security-audit"
   ],
-  "author": "Brett Stark",
+  "author": "BuildProven",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "setup.js",

--- a/setup.js
+++ b/setup.js
@@ -125,6 +125,7 @@ const { runInteractiveFlow } = require('./lib/interactive/questions')
 const { TemplateLoader } = require('./lib/template-loader')
 const {
   detectExistingWorkflowMode,
+  detectExistingMatrix,
   injectWorkflowMode,
   injectMatrix,
 } = require('./lib/workflow-config')
@@ -693,7 +694,7 @@ Usage: npx create-qa-architect@latest [options]
 SETUP OPTIONS:
   (no args)         Run complete quality automation setup
   --interactive     Interactive mode with guided configuration prompts
-  --update          Update existing configuration
+  --update          Update existing configuration (refreshes quality.yml, preserves detected workflow tier)
   --deps            Add basic dependency monitoring (Free Tier)
   --dependency-monitoring  Same as --deps
   --ci <provider>   Select CI provider: github (default) | gitlab | circleci
@@ -703,7 +704,7 @@ SETUP OPTIONS:
 WORKFLOW TIERS (GitHub Actions optimization):
   --workflow-minimal        Minimal CI (default) - Single Node version, monthly security
                             Budget-first mode: detection-only CI (target <1000 min/month)
-  --workflow-standard       Standard CI - Matrix testing on main, monthly security
+  --workflow-standard       Standard CI - Main-branch tests, monthly security
                             ~15-20 min/commit, ~$5-20/mo for typical projects
   --workflow-comprehensive  Comprehensive CI - Matrix on every push, security inline
                             ~50-100 min/commit, ~$100-350/mo for typical projects
@@ -1651,6 +1652,16 @@ HELP:
           }
         }
 
+        const hasExplicitWorkflowMode =
+          isWorkflowMinimal || isWorkflowStandard || isWorkflowComprehensive
+        const existingMatrixEnabled =
+          fs.existsSync(workflowFile) &&
+          !isMatrixEnabled &&
+          !hasExplicitWorkflowMode
+            ? detectExistingMatrix(process.cwd())
+            : false
+        const matrixEnabled = isMatrixEnabled || existingMatrixEnabled
+
         if (!fs.existsSync(workflowFile)) {
           let templateWorkflow =
             templateLoader.getTemplate(
@@ -1666,7 +1677,7 @@ HELP:
           templateWorkflow = injectWorkflowMode(templateWorkflow, workflowMode)
 
           // Inject matrix testing if enabled (for library authors)
-          templateWorkflow = injectMatrix(templateWorkflow, isMatrixEnabled)
+          templateWorkflow = injectMatrix(templateWorkflow, matrixEnabled)
 
           // Inject collaboration steps
           templateWorkflow = injectCollaborationSteps(templateWorkflow, {
@@ -1677,58 +1688,47 @@ HELP:
           fs.writeFileSync(workflowFile, templateWorkflow)
           console.log(`✅ Added GitHub Actions workflow (${workflowMode} mode)`)
         } else if (isUpdateMode) {
-          // Update existing workflow with new mode if explicitly specified
-          if (
-            isWorkflowMinimal ||
-            isWorkflowStandard ||
-            isWorkflowComprehensive
-          ) {
-            // Load fresh template and re-inject
-            let templateWorkflow =
-              templateLoader.getTemplate(
-                templates,
-                path.join('.github', 'workflows', 'quality.yml')
-              ) ||
-              fs.readFileSync(
-                path.join(__dirname, '.github/workflows/quality.yml'),
-                'utf8'
-              )
-
-            // Inject workflow mode configuration
-            templateWorkflow = injectWorkflowMode(
-              templateWorkflow,
-              workflowMode
+          // Refresh existing workflow from the current template.
+          let templateWorkflow =
+            templateLoader.getTemplate(
+              templates,
+              path.join('.github', 'workflows', 'quality.yml')
+            ) ||
+            fs.readFileSync(
+              path.join(__dirname, '.github/workflows/quality.yml'),
+              'utf8'
             )
 
-            // Inject matrix testing if enabled (for library authors)
-            templateWorkflow = injectMatrix(templateWorkflow, isMatrixEnabled)
+          // Inject workflow mode configuration
+          templateWorkflow = injectWorkflowMode(templateWorkflow, workflowMode)
 
-            // Inject collaboration steps (preserve from existing if present)
-            const existingWorkflow = fs.readFileSync(workflowFile, 'utf8')
-            const hasSlackAlerts =
-              existingWorkflow.includes('SLACK_WEBHOOK_URL')
-            const hasPrComments = existingWorkflow.includes(
-              'PR_COMMENT_PLACEHOLDER'
-            )
+          // Inject matrix testing if enabled (for library authors)
+          templateWorkflow = injectMatrix(templateWorkflow, matrixEnabled)
 
-            templateWorkflow = injectCollaborationSteps(templateWorkflow, {
-              enableSlackAlerts: hasSlackAlerts,
-              enablePrComments: hasPrComments,
-            })
+          // Inject collaboration steps (preserve from existing if present)
+          const existingWorkflow = fs.readFileSync(workflowFile, 'utf8')
+          const hasSlackAlerts = existingWorkflow.includes('SLACK_WEBHOOK_URL')
+          const hasPrComments = existingWorkflow.includes(
+            'PR_COMMENT_PLACEHOLDER'
+          )
 
-            fs.writeFileSync(workflowFile, templateWorkflow)
-            if (workflowMode === 'minimal') {
-              console.log(
-                '⚠️  Minimal mode disables tests and security scans in CI (detection-only).'
-              )
-              console.log(
-                '   Use --workflow-standard to re-enable full CI checks.'
-              )
-            }
+          templateWorkflow = injectCollaborationSteps(templateWorkflow, {
+            enableSlackAlerts: hasSlackAlerts,
+            enablePrComments: hasPrComments,
+          })
+
+          fs.writeFileSync(workflowFile, templateWorkflow)
+          if (workflowMode === 'minimal') {
             console.log(
-              `♻️  Updated GitHub Actions workflow to ${workflowMode} mode`
+              '⚠️  Minimal mode disables tests and security scans in CI (detection-only).'
+            )
+            console.log(
+              '   Use --workflow-standard to re-enable full CI checks.'
             )
           }
+          console.log(
+            `♻️  Updated GitHub Actions workflow to ${workflowMode} mode`
+          )
         }
       }
 
@@ -1918,8 +1918,26 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 
-const licenseDir =
+function validateLicenseDir(dirPath) {
+  const resolved = path.resolve(dirPath)
+  const home = os.homedir()
+  const tmp = os.tmpdir()
+  const isInHome = resolved.startsWith(home + path.sep) || resolved === home
+  const isInTmp = resolved.startsWith(tmp + path.sep) || resolved === tmp
+
+  if (!isInHome && !isInTmp) {
+    console.warn(
+      '⚠️  QAA_LICENSE_DIR must be within home or temp directory, ignoring: ' + dirPath
+    )
+    return path.join(home, '.create-qa-architect')
+  }
+
+  return resolved
+}
+
+const requestedLicenseDir =
   process.env.QAA_LICENSE_DIR || path.join(os.homedir(), '.create-qa-architect')
+const licenseDir = validateLicenseDir(requestedLicenseDir)
 const licenseFile = path.join(licenseDir, 'license.json')
 const usageFile = path.join(licenseDir, 'usage.json')
 const now = new Date()

--- a/tests/licensing.test.js
+++ b/tests/licensing.test.js
@@ -8,6 +8,8 @@
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
+const originalHomedir = os.homedir
+const originalTmpdir = os.tmpdir
 const {
   createTestKeyPair,
   setTestPublicKeyEnv,
@@ -553,6 +555,65 @@ function testShowUpgradeMessageFree() {
 }
 
 /**
+ * Test 9: saveLicense() validates QAA_LICENSE_DIR before writing
+ */
+function testInvalidLicenseDirFallsBackToSafePath() {
+  setupTest()
+  console.log('Test 9: saveLicense() hardens invalid QAA_LICENSE_DIR')
+
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cqa-home-'))
+  const fakeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cqa-tmp-'))
+  const invalidDir = path.join(
+    path.sep,
+    'var',
+    'tmp',
+    `cqa-invalid-${Date.now()}`
+  )
+  const expectedLicenseFile = path.join(
+    fakeHome,
+    '.create-qa-architect',
+    'license.json'
+  )
+
+  os.homedir = () => fakeHome
+  os.tmpdir = () => fakeTmp
+  process.env.QAA_LICENSE_DIR = invalidDir
+
+  try {
+    const result = saveLicense(
+      LICENSE_TIERS.PRO,
+      'QAA-ABCD-EF12-3456-7890',
+      'safe-path@example.com'
+    )
+
+    if (!result.success) {
+      console.error('  ❌ Failed to save license with hardened path')
+      console.error('  Error:', result.error)
+      process.exit(1)
+    }
+
+    if (!fs.existsSync(expectedLicenseFile)) {
+      console.error('  ❌ License was not written to validated fallback path')
+      process.exit(1)
+    }
+
+    if (fs.existsSync(path.join(invalidDir, 'license.json'))) {
+      console.error('  ❌ License should not be written to invalid path')
+      process.exit(1)
+    }
+
+    console.log('  ✅ Invalid QAA_LICENSE_DIR falls back to safe path\n')
+  } finally {
+    removeLicense()
+    os.homedir = originalHomedir
+    os.tmpdir = originalTmpdir
+    process.env.QAA_LICENSE_DIR = TEST_LICENSE_DIR
+    fs.rmSync(fakeHome, { recursive: true, force: true })
+    fs.rmSync(fakeTmp, { recursive: true, force: true })
+  }
+}
+
+/**
  * Test 12: showUpgradeMessage() for PRO tier
  */
 function testShowUpgradeMessagePro() {
@@ -729,6 +790,7 @@ testHasFeature()
 testGetDependencyMonitoringLevel()
 testGetSupportedLanguages()
 testSaveAndRemoveLicense()
+testInvalidLicenseDirFallsBackToSafePath()
 testShowUpgradeMessageFree()
 testShowUpgradeMessagePro()
 testShowLicenseStatusFree()

--- a/tests/template-content-validation.test.js
+++ b/tests/template-content-validation.test.js
@@ -1,7 +1,10 @@
 'use strict'
 
+const { execSync } = require('child_process')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
+const { getDefaultScripts } = require('../config/defaults')
 
 /**
  * Tests for template content validation
@@ -14,6 +17,9 @@ async function testTemplateContentValidation() {
   await testSmartStrategyGeneratorExcludesE2E()
   await testHuskyPrepareScriptCIAware()
   await testDefaultsPrepareScriptCIAware()
+  await testDefaultSecurityAuditStopsOnSelectedManagerFailure()
+  await testDefaultValidatePrePushDoesNotMaskEarlierFailures()
+  await testGeneratedPrePushHookValidatesLicenseDir()
 
   console.log('\n✅ All template content validation tests passed!\n')
 }
@@ -220,6 +226,157 @@ async function testDefaultsPrepareScriptCIAware() {
   }
 
   console.log('  ✅ Defaults config includes CI-aware prepare script')
+}
+
+async function testDefaultSecurityAuditStopsOnSelectedManagerFailure() {
+  console.log('🔍 Testing default security:audit does not mask failures...')
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqa-audit-script-'))
+  const binDir = path.join(tempDir, 'bin')
+  fs.mkdirSync(binDir, { recursive: true })
+  fs.writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '')
+  fs.writeFileSync(
+    path.join(binDir, 'pnpm'),
+    '#!/bin/sh\necho pnpm-fail\nexit 1\n'
+  )
+  fs.chmodSync(path.join(binDir, 'pnpm'), 0o755)
+
+  try {
+    const scripts = getDefaultScripts()
+    let exited = false
+
+    try {
+      execSync(`sh -c '${scripts['security:audit']}'`, {
+        cwd: tempDir,
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+        stdio: 'pipe',
+      })
+    } catch (error) {
+      exited = true
+      const output = `${error.stdout || ''}${error.stderr || ''}`
+      if (!output.includes('pnpm-fail')) {
+        throw new Error(
+          'security:audit did not execute the selected pnpm audit'
+        )
+      }
+    }
+
+    if (!exited) {
+      throw new Error(
+        'security:audit should fail when the selected audit fails'
+      )
+    }
+
+    console.log(
+      '  ✅ security:audit stops on the selected package manager failure'
+    )
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function testDefaultValidatePrePushDoesNotMaskEarlierFailures() {
+  console.log('🔍 Testing default validate:pre-push does not mask failures...')
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqa-pre-push-script-'))
+  const binDir = path.join(tempDir, 'bin')
+  fs.mkdirSync(binDir, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(tempDir, 'package.json'),
+    JSON.stringify({
+      name: 'pre-push-repro',
+      version: '1.0.0',
+      scripts: {
+        'test:changed': 'echo changed-pass',
+      },
+    })
+  )
+
+  fs.writeFileSync(
+    path.join(binDir, 'npm'),
+    `#!/bin/sh
+if [ "$1" = "run" ] && [ "$2" = "test:patterns" ]; then
+  echo patterns-fail
+  exit 1
+fi
+if [ "$1" = "run" ] && [ "$2" = "test:commands" ]; then
+  echo commands-pass
+  exit 0
+fi
+if [ "$1" = "run" ] && [ "$2" = "test:changed" ]; then
+  echo changed-pass
+  exit 0
+fi
+if [ "$1" = "test" ]; then
+  echo fallback-pass
+  exit 0
+fi
+echo unexpected-npm-call "$@"
+exit 1
+`
+  )
+  fs.chmodSync(path.join(binDir, 'npm'), 0o755)
+
+  try {
+    const scripts = getDefaultScripts()
+    let exited = false
+
+    try {
+      execSync(`sh -c '${scripts['validate:pre-push']}'`, {
+        cwd: tempDir,
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+        stdio: 'pipe',
+      })
+    } catch (error) {
+      exited = true
+      const output = `${error.stdout || ''}${error.stderr || ''}`
+      if (!output.includes('patterns-fail')) {
+        throw new Error(
+          'validate:pre-push did not surface the first failing step'
+        )
+      }
+      if (output.includes('fallback-pass')) {
+        throw new Error('validate:pre-push incorrectly fell back to npm test')
+      }
+    }
+
+    if (!exited) {
+      throw new Error(
+        'validate:pre-push should fail when an earlier step fails'
+      )
+    }
+
+    console.log('  ✅ validate:pre-push preserves failures from earlier checks')
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function testGeneratedPrePushHookValidatesLicenseDir() {
+  console.log(
+    '🔍 Testing embedded pre-push quota hook validates QAA_LICENSE_DIR...'
+  )
+
+  const setupScriptPath = path.join(__dirname, '..', 'setup.js')
+  const setupContent = fs.readFileSync(setupScriptPath, 'utf8')
+
+  if (!setupContent.includes('function validateLicenseDir(dirPath)')) {
+    throw new Error(
+      'Embedded pre-push quota hook should validate QAA_LICENSE_DIR'
+    )
+  }
+  if (
+    !setupContent.includes(
+      'QAA_LICENSE_DIR must be within home or temp directory'
+    )
+  ) {
+    throw new Error(
+      'Embedded pre-push quota hook should warn on invalid QAA_LICENSE_DIR'
+    )
+  }
+
+  console.log('  ✅ Embedded pre-push quota hook validates QAA_LICENSE_DIR')
 }
 
 // Run tests

--- a/tests/workflow-tiers.test.js
+++ b/tests/workflow-tiers.test.js
@@ -160,6 +160,10 @@ function createTempGitRepo() {
       workflowContent.includes('branches: [main, master, develop]'),
       'Should scope triggers to main/master/develop branches'
     )
+    assert(
+      workflowContent.includes("github.ref == 'refs/heads/main' &&"),
+      'Should gate standard-mode tests to main branch'
+    )
     // Standard: single Node version (matrix is comprehensive-only or --matrix flag)
     assert(
       workflowContent.includes('node-version: [22]'),
@@ -763,6 +767,99 @@ jobs:
 
     console.log(
       '✅ PASS - Provenance-based cleanup: removes qa-architect files, preserves user files\n'
+    )
+  } finally {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  }
+})()
+
+// Test 11: Plain --update refreshes quality.yml while preserving detected mode
+;(() => {
+  console.log('Test 11: Plain --update refreshes existing workflow template')
+  const testDir = createTempGitRepo()
+
+  try {
+    const setupPath = path.join(__dirname, '../setup.js')
+    execSync(`QAA_DEVELOPER=true node ${setupPath} --workflow-standard`, {
+      cwd: testDir,
+      stdio: 'pipe',
+    })
+
+    const workflowPath = path.join(
+      testDir,
+      '.github',
+      'workflows',
+      'quality.yml'
+    )
+
+    // Simulate an older standard workflow missing the main-branch test gate.
+    const staleWorkflow = fs
+      .readFileSync(workflowPath, 'utf8')
+      .replace("      github.ref == 'refs/heads/main' &&\n", '')
+    fs.writeFileSync(workflowPath, staleWorkflow)
+
+    execSync(`QAA_DEVELOPER=true node ${setupPath} --update`, {
+      cwd: testDir,
+      stdio: 'pipe',
+    })
+
+    const refreshedWorkflow = fs.readFileSync(workflowPath, 'utf8')
+    assert(
+      refreshedWorkflow.includes('# WORKFLOW_MODE: standard'),
+      'Plain update should preserve detected workflow mode'
+    )
+    assert(
+      refreshedWorkflow.includes("github.ref == 'refs/heads/main' &&"),
+      'Plain update should refresh workflow template content'
+    )
+
+    console.log(
+      '✅ PASS - Plain update refreshes workflow content while preserving mode\n'
+    )
+  } finally {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  }
+})()
+
+// Test 12: Plain --update preserves existing matrix configuration
+;(() => {
+  console.log('Test 12: Plain --update preserves existing matrix configuration')
+  const testDir = createTempGitRepo()
+
+  try {
+    const setupPath = path.join(__dirname, '../setup.js')
+    execSync(
+      `QAA_DEVELOPER=true node ${setupPath} --workflow-standard --matrix`,
+      {
+        cwd: testDir,
+        stdio: 'pipe',
+      }
+    )
+
+    const workflowPath = path.join(
+      testDir,
+      '.github',
+      'workflows',
+      'quality.yml'
+    )
+
+    execSync(`QAA_DEVELOPER=true node ${setupPath} --update`, {
+      cwd: testDir,
+      stdio: 'pipe',
+    })
+
+    const refreshedWorkflow = fs.readFileSync(workflowPath, 'utf8')
+    assert(
+      refreshedWorkflow.includes('# MATRIX_ENABLED: true'),
+      'Plain update should preserve existing matrix marker'
+    )
+    assert(
+      refreshedWorkflow.includes('node-version: [20, 22]'),
+      'Plain update should preserve existing matrix node versions'
+    )
+
+    console.log(
+      '✅ PASS - Plain update preserves existing matrix configuration\n'
     )
   } finally {
     fs.rmSync(testDir, { recursive: true, force: true })

--- a/tests/workflow-tiers.test.js
+++ b/tests/workflow-tiers.test.js
@@ -198,10 +198,10 @@ function createTempGitRepo() {
       'Should have comprehensive mode marker'
     )
 
-    // Comprehensive mode includes path filters (security runs inline, not on schedule)
+    // Comprehensive mode removes path filters so every change gets full CI.
     assert(
-      workflowContent.includes('paths-ignore:'),
-      'Should have path filters'
+      !workflowContent.includes('paths-ignore:'),
+      'Should NOT have path filters'
     )
 
     // Comprehensive: no schedule trigger (security runs inline on every push)
@@ -290,8 +290,8 @@ function createTempGitRepo() {
       'Initial setup should be comprehensive'
     )
     assert(
-      workflowContent.includes('paths-ignore:'),
-      'Comprehensive should have path filters'
+      !workflowContent.includes('paths-ignore:'),
+      'Comprehensive should NOT have path filters'
     )
 
     // Update to minimal mode


### PR DESCRIPTION
## Summary
- cut release `5.13.3`
- harden license write paths and embedded pre-push quota handling for `QAA_LICENSE_DIR`
- preserve existing matrix workflows on plain `--update` and fix generated script failure masking
- align BuildProven branding and standard-tier workflow docs with actual behavior

## Verification
- npm run prerelease
