### PR TITLE
chore: release v5.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.4] - 2026-04-19
+
+### Fixed
+
+- **ESM target project support (#101)** — `create-qa-architect` now detects `"type": "module"` in the target project's `package.json` and emits `commitlint.config.cjs` instead of `.js`, preventing `ReferenceError: module is not defined in ES module scope`. When the target already has `vitest@>=3`, the injected `@vitest/coverage-v8` version is aligned to the same major to avoid `ERESOLVE` peer-dep failures.
+- **High-severity npm audit advisory** in the `basic-ftp` transitive chain is now resolved via `package.json` overrides; additional overrides for `tmp`, `inquirer`, `external-editor`, and `esbuild` clear up the `@lhci/cli` cluster. Remaining advisories are all dev-only vite path traversal inside `vitest@2`'s internal dependency tree (not reachable in published builds).
+
 ## [5.13.3] - 2026-04-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**npm**: `create-qa-architect` | **Version**: 5.13.3
+**npm**: `create-qa-architect` | **Version**: 5.13.4
 
 ## Project Overview
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@
 
 **Business timelines may differ**: Customer acquisition, revenue ramp, and market penetration follow normal curves regardless of build speed.
 
-## Current Version: 5.13.3
+## Current Version: 5.13.4
 
 ## Completed
 

--- a/docs/dev_guide/CONVENTIONS.md
+++ b/docs/dev_guide/CONVENTIONS.md
@@ -11,7 +11,7 @@ QA Architect (`create-qa-architect`) is a CLI tool that bootstraps quality autom
 
 **Entry point:** `setup.js` — CLI argument parsing and orchestration. Run as `npx create-qa-architect` or `node setup.js`.
 
-**npm package:** `create-qa-architect` v5.13.3 (published via GitHub trusted publishing)
+**npm package:** `create-qa-architect` v5.13.4 (published via GitHub trusted publishing)
 
 ## Directory Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.3",
+  "version": "5.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-qa-architect",
-      "version": "5.13.3",
+      "version": "5.13.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@npmcli/package-json": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.3",
+  "version": "5.13.4",
   "description": "QA Architect - Bootstrap quality automation for JavaScript/TypeScript and Python projects with GitHub Actions, pre-commit hooks, linting, formatting, and smart test strategy",
   "main": "setup.js",
   "bin": {


### PR DESCRIPTION
## Summary

Release v5.13.4. Ships two recently merged fixes to npm:

- **ESM target project support** (#101) — merged in #129
- **npm audit high-sev resolution** — merged in #128

## Changes

- Bump `package.json` version 5.13.3 → 5.13.4
- Changelog entry
- Sync version references in `CLAUDE.md`, `ROADMAP.md`, `docs/dev_guide/CONVENTIONS.md`
- Regenerate `package-lock.json`

On merge, `.github/workflows/release.yml` will detect the version bump and publish to npm via trusted publishing (no OTP required).

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes v5.13.4 to npm after merge
- [ ] `npx create-qa-architect@latest --version` reports 5.13.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)