### PR TITLE
fix(ci): pin npm to 10.9.2 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      # Pin npm to a known-good version that supports OIDC trusted publishing.
+      # `npm install -g npm@latest` fails on self-upgrade under Node 22 due to
+      # a MODULE_NOT_FOUND (promise-retry) regression in npm 11.x arborist.
+      - name: Pin npm for OIDC trusted publishing
+        run: npm install -g npm@10.9.2
 
       - name: Install dependencies
         run: npm ci --no-audit


### PR DESCRIPTION
## Summary

Unblocks v5.13.4 release. `npm install -g npm@latest` currently fails on Node 22 with \`MODULE_NOT_FOUND: promise-retry\`, a known regression in npm 11.x arborist's \`rebuild.js\`.

Pinning to npm 10.9.2, which still supports OIDC trusted publishing.

## Evidence

- [Release run 24633472471](https://github.com/buildproven/qa-architect/actions/runs/24633472471) — failed on step \"Upgrade npm for OIDC trusted publishing\"
- v5.13.3 previously worked because it ran before the npm 11.x cut

## Follow-up

After this merges, retag v5.13.4 → trigger release → verify publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)