### PR TITLE
fix(ci): pin npm to 11.5.2 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,12 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Pin npm to a known-good version that supports OIDC trusted publishing.
-      # `npm install -g npm@latest` fails on self-upgrade under Node 22 due to
-      # a MODULE_NOT_FOUND (promise-retry) regression in npm 11.x arborist.
+      # OIDC trusted publishing requires npm >= 11.5. We pin to 11.5.2 (the
+      # first OIDC-stable release) instead of `npm@latest` to avoid the
+      # MODULE_NOT_FOUND (promise-retry) regression hit when self-upgrading
+      # over the setup-node-provided npm on top of the newest 11.x.
       - name: Pin npm for OIDC trusted publishing
-        run: npm install -g npm@10.9.2
+        run: npm install -g npm@11.5.2
 
       - name: Install dependencies
         run: npm ci --no-audit


### PR DESCRIPTION
## Summary

Previous pin in #131 to npm 10.9.2 broke publish with 404 — OIDC trusted publishing requires npm >= 11.5. Pinning to 11.5.2 (first OIDC-stable) avoids both the 404 and the 11.12.x self-upgrade \`MODULE_NOT_FOUND: promise-retry\` regression that started this cascade.

## Evidence

- [Run 24633594304](https://github.com/buildproven/qa-architect/actions/runs/24633594304) — failed at publish step with \`npm error 404 'create-qa-architect@5.13.4' is not in this registry\`

## Follow-up

After merge: re-point \`v5.13.4\` tag → workflow reruns → verify npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)