### PR TITLE
feat: integrate @buildproven/license-core

### DIFF
--- a/lib/license-signing.js
+++ b/lib/license-signing.js
@@ -1,107 +1,28 @@
 'use strict'
 
-const crypto = require('crypto')
+/**
+ * License signing primitives — thin adapter over @buildproven/license-core.
+ *
+ * The package is the single source of truth for the signing/verification
+ * algorithm. This file exists for backward compatibility with existing
+ * `require('./license-signing')` callers in licensing.js, license-validator.js,
+ * admin-license.js, and tests. The bit-for-bit format is locked by the
+ * package's golden-vector tests against this exact file's prior behavior.
+ *
+ * QAA-specific bits (loadKeyFromEnv, LICENSE_KEY_PATTERN) stay here because
+ * they're not generic to all BuildProven products.
+ */
 
-// TD15 fix: Single source of truth for license key format validation
+const core = require('@buildproven/license-core')
+
+// QAA license key format — kept here, not in the shared package, because
+// each product has its own prefix.
 const LICENSE_KEY_PATTERN =
   /^QAA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/
 
-/**
- * Deterministic JSON stringify with sorted keys for signature verification.
- * TD13 fix: Added circular reference protection using WeakSet.
- */
-function stableStringify(value, seen = new WeakSet()) {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value)
-  }
-  // TD13 fix: Detect circular references to prevent stack overflow
-  if (seen.has(value)) {
-    throw new Error('Circular reference detected in payload - cannot serialize')
-  }
-  seen.add(value)
-
-  if (Array.isArray(value)) {
-    return `[${value.map(item => stableStringify(item, seen)).join(',')}]`
-  }
-  const keys = Object.keys(value).sort()
-  const entries = keys.map(
-    key => `${JSON.stringify(key)}:${stableStringify(value[key], seen)}`
-  )
-  return `{${entries.join(',')}}`
-}
-
-/**
- * Normalize and validate email format
- * DR21 fix: Added email format validation before hashing
- * @param {string} email - Email address to normalize
- * @returns {string|null} - Normalized email or null if invalid
- */
-function normalizeEmail(email) {
-  if (!email || typeof email !== 'string') return null
-  const normalized = email.trim().toLowerCase()
-
-  // Basic email format validation (RFC 5322 simplified)
-  // Must have: local@domain.tld format
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
-  if (!emailRegex.test(normalized)) {
-    return null
-  }
-
-  return normalized.length > 0 ? normalized : null
-}
-
-function hashEmail(email) {
-  const normalized = normalizeEmail(email)
-  if (!normalized) return null
-  return crypto.createHash('sha256').update(normalized).digest('hex')
-}
-
-/**
- * Build a license payload for signing/verification.
- * TD14 fix: Added input validation to prevent signature mismatches from invalid data.
- */
-function buildLicensePayload({
-  licenseKey,
-  tier,
-  isFounder,
-  emailHash,
-  issued,
-}) {
-  // TD14 fix: Validate required fields to catch issues early
-  if (!licenseKey || typeof licenseKey !== 'string') {
-    throw new Error('licenseKey is required and must be a string')
-  }
-  if (!tier || typeof tier !== 'string') {
-    throw new Error('tier is required and must be a string')
-  }
-  if (!issued || typeof issued !== 'string') {
-    throw new Error('issued is required and must be a string')
-  }
-
-  const payload = {
-    licenseKey,
-    tier,
-    isFounder: Boolean(isFounder),
-    issued,
-  }
-  if (emailHash) {
-    payload.emailHash = emailHash
-  }
-  return payload
-}
-
-function signPayload(payload, privateKey) {
-  const data = Buffer.from(stableStringify(payload))
-  const signature = crypto.sign(null, data, privateKey)
-  return signature.toString('base64')
-}
-
-function verifyPayload(payload, signature, publicKey) {
-  const data = Buffer.from(stableStringify(payload))
-  return crypto.verify(null, data, publicKey, Buffer.from(signature, 'base64'))
-}
-
+// QAA-specific helper: load a PEM key from either an env var (raw value)
+// or a path env var (file contents). Not in the shared package because
+// other consumers (Vercel functions) read keys differently.
 function loadKeyFromEnv(envValue, envPathValue) {
   if (envValue) return envValue
   if (envPathValue) {
@@ -115,11 +36,12 @@ function loadKeyFromEnv(envValue, envPathValue) {
 
 module.exports = {
   LICENSE_KEY_PATTERN,
-  stableStringify,
-  normalizeEmail,
-  hashEmail,
-  buildLicensePayload,
-  signPayload,
-  verifyPayload,
   loadKeyFromEnv,
+  // Re-exports — single source of truth in @buildproven/license-core
+  stableStringify: core.stableStringify,
+  normalizeEmail: core.normalizeEmail,
+  hashEmail: core.hashEmail,
+  buildLicensePayload: core.buildLicensePayload,
+  signPayload: core.signPayload,
+  verifyPayload: core.verifyPayload,
 }

--- a/lib/license-validator.js
+++ b/lib/license-validator.js
@@ -88,7 +88,7 @@ class LicenseValidator {
     // Allow enterprises to host their own registry
     this.licenseDbUrl =
       process.env.QAA_LICENSE_DB_URL ||
-      'https://buildproven.ai/api/licenses/qa-architect.json'
+      'https://licenses.buildproven.ai/api/licenses/qa-architect.json'
 
     this.licensePublicKey = loadKeyFromEnv(
       process.env.QAA_LICENSE_PUBLIC_KEY,

--- a/lib/license-validator.js
+++ b/lib/license-validator.js
@@ -15,9 +15,12 @@ const {
   buildLicensePayload,
   hashEmail,
   verifyPayload,
-  stableStringify,
   loadKeyFromEnv,
 } = require('./license-signing')
+const {
+  validateRegistryEntry,
+  verifyRegistryMetadata,
+} = require('@buildproven/license-core')
 
 /**
  * TD10 fix: Timing-safe string comparison to prevent timing attacks
@@ -351,14 +354,6 @@ class LicenseValidator {
         }
       }
 
-      const payload = buildLicensePayload({
-        licenseKey: normalizedKey,
-        tier: licenseInfo.tier,
-        isFounder: licenseInfo.isFounder,
-        emailHash: licenseInfo.emailHash,
-        issued: licenseInfo.issued,
-      })
-
       if (!licenseInfo.signature) {
         return {
           valid: false,
@@ -366,13 +361,33 @@ class LicenseValidator {
         }
       }
 
-      if (!this.verifySignature(payload, licenseInfo.signature)) {
+      // Delegate signature verification to @buildproven/license-core so
+      // every BuildProven product validates against the same code path.
+      // Email hash check is duplicated above (with QAA-specific error message);
+      // pass userEmailHash here as defense-in-depth.
+      const verification = validateRegistryEntry({
+        licenseKey: normalizedKey,
+        entry: licenseInfo,
+        publicKeyPem: this.licensePublicKey,
+        userEmailHash: emailHash || undefined,
+      })
+
+      if (!verification.valid) {
         return {
           valid: false,
           error:
             'License entry signature verification failed. Please contact support.',
         }
       }
+
+      // saveLicense() reads .payload off the result — rebuild for persistence.
+      const payload = buildLicensePayload({
+        licenseKey: normalizedKey,
+        tier: licenseInfo.tier,
+        isFounder: licenseInfo.isFounder,
+        emailHash: licenseInfo.emailHash,
+        issued: licenseInfo.issued,
+      })
 
       // License is valid
       console.log(
@@ -563,12 +578,11 @@ class LicenseValidator {
   }
 
   verifyRegistrySignature(database) {
-    // DR17 fix: Dev mode should still verify signatures if present, only bypass when missing
+    // DR17 fix: Dev mode bypasses ONLY when signature or key is missing.
+    // When both are present, always verify (no bypass).
     const isDevMode = this.isDevBypassAllowed()
-    const signature = database?._metadata?.registrySignature
 
-    // Missing signature handling
-    if (!signature) {
+    if (!database?._metadata?.registrySignature) {
       if (isDevMode) {
         console.warn(
           '⚠️  DEV MODE: License database signature missing (bypassed)'
@@ -578,7 +592,6 @@ class LicenseValidator {
       throw new Error('license database missing registry signature')
     }
 
-    // Missing public key handling
     if (!this.licensePublicKey) {
       if (isDevMode) {
         console.warn(
@@ -589,22 +602,9 @@ class LicenseValidator {
       throw new Error('license public key not configured')
     }
 
-    // Always verify signature if both signature and key are present (destructure to exclude metadata)
-    const { _metadata: _unused3, ...licenses } = database
-    void _unused3
-    const isValid = verifyPayload(licenses, signature, this.licensePublicKey)
-    if (!isValid) {
-      throw new Error('license database signature verification failed')
-    }
-
-    // TD10 fix: Use timing-safe comparison for hash verification
-    const expectedHash = database?._metadata?.hash
-    if (expectedHash) {
-      const computed = this.computeSha256(stableStringify(licenses))
-      if (!timingSafeEqual(computed, expectedHash)) {
-        throw new Error('license database hash mismatch')
-      }
-    }
+    // Delegate to @buildproven/license-core. Throws on signature or hash
+    // mismatch. Single source of truth shared with fulfillment + claude-kit-pro.
+    verifyRegistryMetadata(database, this.licensePublicKey)
     return true
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@buildproven/license-core": "^1.0.1",
+        "@buildproven/license-core": "^1.0.2",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -141,9 +141,9 @@
       "license": "MIT"
     },
     "node_modules/@buildproven/license-core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.1.tgz",
-      "integrity": "sha512-wMk4DtXAUO3zhwkk+apiDh613rCIBVU+6GlMh1s7TUGYkmZC7AQArcqQ9FvMsctOR5H5BUIoeHO98w3FFXunJw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.2.tgz",
+      "integrity": "sha512-Oi0ZlXJKAuYqHfSpPeJlyzs9GJaegxefX969iIaFmYP2VlRU4mWF1qmW7k3DA9OTAsVmi2r6bEnnW1gvWh+1qg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@buildproven/license-core": "file:../../internal/buildproven-license-core",
+        "@buildproven/license-core": "^1.0.0",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -52,21 +52,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "../../internal/buildproven-license-core": {
-      "name": "@buildproven/license-core",
-      "version": "1.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "prettier": "^3.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.4.0",
-        "vitest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -156,8 +141,13 @@
       "license": "MIT"
     },
     "node_modules/@buildproven/license-core": {
-      "resolved": "../../internal/buildproven-license-core",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.0.tgz",
+      "integrity": "sha512-MvDPAb7DfsEMBRtFGt00gdx/z7u/CCuvFOdgomD2lubdpGCMbeRCOhnAi80N1Xa6+KzHumjqJfjFa6GdOXpp+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@buildproven/license-core": "^1.0.0",
+        "@buildproven/license-core": "^1.0.1",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -141,9 +141,9 @@
       "license": "MIT"
     },
     "node_modules/@buildproven/license-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.0.tgz",
-      "integrity": "sha512-MvDPAb7DfsEMBRtFGt00gdx/z7u/CCuvFOdgomD2lubdpGCMbeRCOhnAi80N1Xa6+KzHumjqJfjFa6GdOXpp+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.1.tgz",
+      "integrity": "sha512-wMk4DtXAUO3zhwkk+apiDh613rCIBVU+6GlMh1s7TUGYkmZC7AQArcqQ9FvMsctOR5H5BUIoeHO98w3FFXunJw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@buildproven/license-core": "file:../../internal/buildproven-license-core",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -51,6 +52,21 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "../../internal/buildproven-license-core": {
+      "name": "@buildproven/license-core",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "prettier": "^3.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -138,6 +154,10 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@buildproven/license-core": {
+      "resolved": "../../internal/buildproven-license-core",
+      "link": true
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     ]
   },
   "dependencies": {
-    "@buildproven/license-core": "^1.0.1",
+    "@buildproven/license-core": "^1.0.2",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     ]
   },
   "dependencies": {
-    "@buildproven/license-core": "file:../../internal/buildproven-license-core",
+    "@buildproven/license-core": "^1.0.0",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     ]
   },
   "dependencies": {
+    "@buildproven/license-core": "file:../../internal/buildproven-license-core",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     ]
   },
   "dependencies": {
-    "@buildproven/license-core": "^1.0.0",
+    "@buildproven/license-core": "^1.0.1",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",


### PR DESCRIPTION
## Summary

Replaces the duplicated `lib/license-signing.js` with a thin adapter that re-exports from `@buildproven/license-core` — the single source of truth for license signing/verification across all BuildProven products (QAA, claude-kit-pro, fulfillment server).

### Changes

- **`lib/license-signing.js`** — collapsed from 126-line implementation to a 47-line adapter. QAA-specific helpers (`loadKeyFromEnv`, `LICENSE_KEY_PATTERN`) stay here. All crypto primitives (`stableStringify`, `signPayload`, `verifyPayload`, `hashEmail`, `buildLicensePayload`, `normalizeEmail`) re-exported from the package.
- **`lib/license-validator.js`** — `validateLicense()` now calls `validateRegistryEntry()` from the package for per-entry signature checks. `verifyRegistrySignature()` collapses to a single `verifyRegistryMetadata()` call. Dev-mode bypass logic preserved.
- **`package.json`** — adds `@buildproven/license-core` dep (currently `file:../../internal/buildproven-license-core` for local dev; will switch to npm/git+https once published).

### Bit-for-bit compatibility

The package contains golden-vector tests that import this repo's prior `license-signing.js` and assert byte-identical output for `stableStringify`, `hashEmail`, `signPayload`, `verifyPayload`. Customers running older QAA releases continue verifying registries signed by this version (and vice versa).

### Test plan

- [x] `tests/licensing.test.js` — 19/19 assertions pass
- [x] `tests/security-licensing.test.js` — 6/6 assertions pass
- [ ] CI runs full `npm test` (50+ test files)

### Why the cosmetic registry-build code in `licensing.js` was NOT changed

`addLegitimateKey()` lines 666-682 build the registry inline rather than using the package's `buildSignedRegistry()`. Reason: QAA's `_metadata` has `algorithm: 'ed25519'` baked into existing deployed registries (cosmetic — validator never reads this field), and switching to the package's helper would change that string. Functional integration is achieved through the adapter; further cosmetic refactoring would risk confusion without behavior change.