### PR TITLE
chore: release v5.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.5] - 2026-04-28
+
+### Changed
+
+- **License registry URL** updated to `https://licenses.buildproven.ai/api/licenses/qa-architect.json`. The fulfillment service is now live at this Vercel-hosted endpoint (signed JSON, RSA-SHA256). Override with `QAA_LICENSE_DB_URL` for self-hosted enterprise registries.
+- **Internal:** signing primitives now imported from `@buildproven/license-core` (a published npm package, MIT). The local `lib/license-signing.js` is a thin re-export shim. `lib/license-validator.js` uses `validateRegistryEntry` and `verifyRegistryMetadata` from the package. Bit-for-bit signature compatibility with prior releases verified via golden-vector tests.
+
 ## [5.13.4] - 2026-04-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.4",
+  "version": "5.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-qa-architect",
-      "version": "5.13.4",
+      "version": "5.13.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@buildproven/license-core": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qa-architect",
-  "version": "5.13.4",
+  "version": "5.13.5",
   "description": "QA Architect - Bootstrap quality automation for JavaScript/TypeScript and Python projects with GitHub Actions, pre-commit hooks, linting, formatting, and smart test strategy",
   "main": "setup.js",
   "bin": {


### PR DESCRIPTION
Patch release pointing the license validator at the live registry URL.

## Changes
- License registry URL → `https://licenses.buildproven.ai/api/licenses/qa-architect.json`
- CHANGELOG entry

The release workflow auto-publishes on tag push after this merges.