### PR TITLE
fix(deploy): fix slug extraction for .git-suffixed remote URLs

### DIFF
--- a/scripts/deploy-consumers.sh
+++ b/scripts/deploy-consumers.sh
@@ -165,7 +165,7 @@ wait_for_ci() {
 
   # Extract owner/repo from URL (handles both HTTPS and SSH)
   local repo_slug
-  repo_slug=$(echo "$remote_url" | sed -E 's|^.*[:/]([^/]+/[^/]+)(\.git)?$|\1|')
+  repo_slug=$(echo "$remote_url" | sed -E 's|\.git$||' | sed -E 's|^.*[:/]([^/]+/[^/]+)$|\1|')
 
   # Get the current branch
   local branch


### PR DESCRIPTION
Two-pass sed (strip .git then extract owner/repo) replaces broken lazy quantifier that macOS sed doesn't support. Fixes CI wait always showing 'no runs found' and timing out.