### PR TITLE
fix(license): auto-load bundled public-key.pem for buyers with no env vars

### DIFF
--- a/lib/license-validator.js
+++ b/lib/license-validator.js
@@ -22,6 +22,18 @@ const {
   verifyRegistryMetadata,
 } = require('@buildproven/license-core')
 
+function loadBundledPublicKey() {
+  try {
+    const keyPath = path.join(__dirname, '..', 'public-key.pem')
+    if (fs.existsSync(keyPath)) {
+      return fs.readFileSync(keyPath, 'utf8')
+    }
+  } catch {
+    // bundled key unavailable; caller will warn
+  }
+  return null
+}
+
 /**
  * TD10 fix: Timing-safe string comparison to prevent timing attacks
  * on hash/signature verification.
@@ -90,10 +102,11 @@ class LicenseValidator {
       process.env.QAA_LICENSE_DB_URL ||
       'https://licenses.buildproven.ai/api/licenses/qa-architect.json'
 
-    this.licensePublicKey = loadKeyFromEnv(
-      process.env.QAA_LICENSE_PUBLIC_KEY,
-      process.env.QAA_LICENSE_PUBLIC_KEY_PATH
-    )
+    this.licensePublicKey =
+      loadKeyFromEnv(
+        process.env.QAA_LICENSE_PUBLIC_KEY,
+        process.env.QAA_LICENSE_PUBLIC_KEY_PATH
+      ) || loadBundledPublicKey()
 
     // DR14 fix: Add in-memory cache with 5-minute TTL
     this.dbCache = null


### PR DESCRIPTION
## Summary
- `LicenseValidator` now falls back to the `public-key.pem` bundled in the npm package when neither `QAA_LICENSE_PUBLIC_KEY` nor `QAA_LICENSE_PUBLIC_KEY_PATH` is set
- Without this, normal buyers had signature verification silently skipped (key was `null` → `verifySignature` returned `isDevBypassAllowed()` which is `false` in prod but emitted a warning and skipped verification)
- Env vars still take precedence, so enterprise overrides and tests are unaffected

## Test plan
- [ ] `node tests/license-validator-integrity.test.js` — passes (valid sigs accepted, invalid rejected)
- [ ] `node tests/licensing.test.js` — passes
- [ ] `npm run test:unit` — all green
- [ ] Manual: `node -e "const {LicenseValidator}=require('./lib/license-validator'); const v=new LicenseValidator(); console.log(!!v.licensePublicKey)"` → `true` without any env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)