### PR TITLE
refactor(license): import normalizeLicenseKey + isDeveloperMode from core

### DIFF
--- a/lib/license-signing.js
+++ b/lib/license-signing.js
@@ -44,4 +44,5 @@ module.exports = {
   buildLicensePayload: core.buildLicensePayload,
   signPayload: core.signPayload,
   verifyPayload: core.verifyPayload,
+  normalizeLicenseKey: core.normalizeLicenseKey,
 }

--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -15,7 +15,11 @@ const {
   stableStringify,
   verifyPayload,
   loadKeyFromEnv,
+  normalizeLicenseKey,
 } = require('./license-signing')
+const {
+  isDeveloperMode: coreIsDeveloperMode,
+} = require('@buildproven/license-core')
 const { validateLicenseDir } = require('./license-validator')
 
 // License storage locations
@@ -55,11 +59,6 @@ const LICENSE_TIERS = Object.freeze({
   FREE: 'FREE',
   PRO: 'PRO',
 })
-
-function normalizeLicenseKey(key) {
-  if (typeof key !== 'string') return ''
-  return key.trim().toUpperCase()
-}
 
 /**
  * DR23 fix: Deep freeze helper to prevent mutation at any level
@@ -210,42 +209,20 @@ const FEATURES = deepFreeze({
 
 /**
  * Check if developer/owner mode is enabled
- * Allows the tool creator to use all features without a license
- * Security: Production mode always enforces license checks
+ * Allows the tool creator to use all features without a license.
+ *
+ * Delegates to @buildproven/license-core's isDeveloperMode — the single shared
+ * implementation (extracted from this very function) that every product uses, so
+ * the owner-bypass logic can't drift between qa-architect and claude-kit-pro.
+ * Core enforces the identical contract: NODE_ENV=production hard-disables the
+ * bypass; otherwise the QAA_DEVELOPER env var OR the .cqa-developer marker file
+ * enables it; an ELOOP on the marker path throws in production (tamper signal).
  */
 function isDeveloperMode() {
-  // Security: Production mode never allows developer bypass
-  if (process.env.NODE_ENV === 'production') {
-    return false
-  }
-
-  // Check environment variable
-  if (process.env.QAA_DEVELOPER === 'true') {
-    return true
-  }
-
-  // Check for marker file in license directory
-  try {
-    const developerMarkerFile = path.join(getLicenseDir(), '.cqa-developer')
-    if (fs.existsSync(developerMarkerFile)) {
-      return true
-    }
-  } catch (error) {
-    // DR10 fix: Halt on ELOOP in production (security issue)
-    if (error?.code === 'ELOOP') {
-      const message =
-        'Symlink loop detected in license directory - possible security issue'
-      if (process.env.NODE_ENV === 'production') {
-        throw new Error(message)
-      } else {
-        console.warn(`⚠️  ${message}`)
-      }
-    } else if (process.env.DEBUG && error?.code !== 'ENOENT') {
-      console.warn(`⚠️  Developer mode check failed: ${error.message}`)
-    }
-  }
-
-  return false
+  return coreIsDeveloperMode({
+    envVar: 'QAA_DEVELOPER',
+    markerFile: path.join(getLicenseDir(), '.cqa-developer'),
+  })
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@buildproven/license-core": "^1.0.2",
+        "@buildproven/license-core": "^1.1.0",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@buildproven/license-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.0.2.tgz",
-      "integrity": "sha512-Oi0ZlXJKAuYqHfSpPeJlyzs9GJaegxefX969iIaFmYP2VlRU4mWF1qmW7k3DA9OTAsVmi2r6bEnnW1gvWh+1qg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@buildproven/license-core/-/license-core-1.1.0.tgz",
+      "integrity": "sha512-Bc67RCQEPiWDXwo9fnoWlkiKguUFk9mz6wfsAOGyGbwTkgok1O84AovpIwmttGprpxPdF3VR4BVkNDr7pxuC4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@buildproven/license-core": "^1.1.0",
+        "@buildproven/license-core": "1.1.0",
         "@npmcli/package-json": "^7.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     ]
   },
   "dependencies": {
-    "@buildproven/license-core": "^1.0.2",
+    "@buildproven/license-core": "^1.1.0",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     ]
   },
   "dependencies": {
-    "@buildproven/license-core": "^1.1.0",
+    "@buildproven/license-core": "1.1.0",
     "@npmcli/package-json": "^7.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",


### PR DESCRIPTION
**Part A.2** of the anti-double-build work. qa-architect already imports `@buildproven/license-core` for signing/validation but still kept local copies of `normalizeLicenseKey` and `isDeveloperMode`. This removes the last duplication.

> ⚠️ **Blocked on** buildproven/license-core#2 — needs `@buildproven/license-core@1.1.0` on npm. Verified locally against a 1.1.0 build.

## Changes
- `normalizeLicenseKey` → re-exported from core via the `license-signing` adapter
- `isDeveloperMode` → delegates to core's `isDeveloperMode({ envVar: 'QAA_DEVELOPER', markerFile })`. Core's logic was **extracted from this very function**, so the contract is identical (production hard-disable, env var, `.cqa-developer` marker, ELOOP tamper signal). Only dropped: two non-contractual `console.warn` diagnostics (ELOOP-in-dev, DEBUG) — no test asserted them, core is canonical now.
- bump dep `^1.0.2` → `^1.1.0`

## Required a core hardening (license-core#2)
core's `normalizeLicenseKey`/`isValidLicenseKey` threw on non-string input; qa-architect's original guarded it. license-core#2 restores the guard — caught here by `licensing.test.js` feeding `undefined`.

**Net −24 LoC.** ESLint clean; licensing, security-licensing, license-revalidation, validator-integrity, tier-enforcement suites all green.

> 🛠️ Incidental: the primary qa-architect checkout had `core.bare=true` (leftover from a `git filter-repo` run) blocking all git ops. Fixed in-place (config-only, reversible). Not part of this branch — flagging so you know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)