### PR TITLE
fix(security): run security gate on PRs + post vibe-audit as PR comment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -152,7 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: detect-maturity
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.detect-maturity.outputs.has-deps == 'true'
+    # Security MUST run at PR time, not only monthly — "CI green" has to mean
+    # "secret-scanned + SAST-clean". Runs on PRs, direct pushes, the monthly
+    # scheduled deep scan, and manual dispatch.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'push' ||
+       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.detect-maturity.outputs.has-deps == 'true'
 
     steps:
       - name: Checkout code
@@ -277,6 +283,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMGREP_VERSION: '1.85.0'
           SEMGREP_ENABLE_VERSION_CHECK: 'false'
+
+      # QA Architect's own vibe-code audit — the AI-native rules (secrets in
+      # client bundles, unscoped data access, injection) that generic SAST
+      # misses. Report-only for now: posts findings as a PR comment so teams
+      # see them on every PR without breaking builds on pre-existing issues.
+      - name: Install semgrep CLI for vibe-audit
+        run: pipx install semgrep==1.85.0 || pip install semgrep==1.85.0
+
+      - name: QA Architect vibe-code audit
+        run: |
+          echo "🔍 Running QA Architect vibe-code security audit..."
+          if [ -f setup.js ]; then
+            node setup.js --audit --out qa-audit-report.md --no-fail
+          else
+            npx create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
+          fi
+
+      - name: Post audit report as PR comment
+        # always() so the report still posts even if an earlier security step
+        # (gitleaks/semgrep) failed — the audit findings are useful regardless.
+        if: always() && github.event_name == 'pull_request' && hashFiles('qa-audit-report.md') != ''
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: qa-architect-audit
+          path: qa-audit-report.md
 
   # Step 3: Tests - run if test files exist (development+)
   # Smart skip: Draft PRs skip tests (saves CI costs during WIP)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -152,6 +152,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: detect-maturity
+    # Least privilege: this job only needs to read the code and post a PR
+    # comment. Scoping the token here means a compromised scan dependency
+    # cannot push commits, alter releases, or touch other repo resources.
+    permissions:
+      contents: read
+      pull-requests: write
     # Security MUST run at PR time, not only monthly — "CI green" has to mean
     # "secret-scanned + SAST-clean". Runs on PRs, direct pushes, the monthly
     # scheduled deep scan, and manual dispatch.
@@ -297,7 +303,7 @@ jobs:
           if [ -f setup.js ]; then
             node setup.js --audit --out qa-audit-report.md --no-fail
           else
-            npx create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
+            npx --yes create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
           fi
 
       - name: Post audit report as PR comment


### PR DESCRIPTION
The security job only ran on schedule/workflow_dispatch — so 'CI green'
on a pull request did NOT mean secret-scanned or SAST-clean. Every other
job (tests, detect-maturity) runs at PR time; security uniquely opted out.
Since quality.yml is the template deployed to 15+ consumer repos, this hole
shipped to all of them: a PR could merge with an unsuppressed gitleaks or
semgrep finding.

Changes:
- Un-gate the security job's if: to also run on pull_request and push, not
  just schedule/workflow_dispatch.
- Add a vibe-code audit step that runs qa-architect's OWN --audit rules
  (the AI-native checks generic SAST misses) and posts findings as a sticky
  PR comment. Report-only (--no-fail) for now: on this repo --audit surfaces
  699 pre-existing findings, so blocking on day one would break every
  consumer's next PR. Comment-first is the safe rollout; blocking can follow
  once consumers see clean reports.

Verified:
- consumer-workflow-integration.test.js (all tiers, valid YAML) ✅
- workflow-tiers.test.js ✅
- lint ✅
- --audit --out --no-fail smoke test writes report + exits 0 ✅
- marocchino action SHA verified against the real v2.9.0 tag

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
