### PR TITLE
fix(security): run security gate on PRs + post vibe-audit as PR comment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -152,7 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: detect-maturity
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.detect-maturity.outputs.has-deps == 'true'
+    # Security MUST run at PR time, not only monthly — "CI green" has to mean
+    # "secret-scanned + SAST-clean". Runs on PRs, direct pushes, the monthly
+    # scheduled deep scan, and manual dispatch.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'push' ||
+       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.detect-maturity.outputs.has-deps == 'true'
 
     steps:
       - name: Checkout code
@@ -277,6 +283,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMGREP_VERSION: '1.85.0'
           SEMGREP_ENABLE_VERSION_CHECK: 'false'
+
+      # QA Architect's own vibe-code audit — the AI-native rules (secrets in
+      # client bundles, unscoped data access, injection) that generic SAST
+      # misses. Report-only for now: posts findings as a PR comment so teams
+      # see them on every PR without breaking builds on pre-existing issues.
+      - name: Install semgrep CLI for vibe-audit
+        run: pipx install semgrep==1.85.0 || pip install semgrep==1.85.0
+
+      - name: QA Architect vibe-code audit
+        run: |
+          echo "🔍 Running QA Architect vibe-code security audit..."
+          if [ -f setup.js ]; then
+            node setup.js --audit --out qa-audit-report.md --no-fail
+          else
+            npx create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
+          fi
+
+      - name: Post audit report as PR comment
+        # always() so the report still posts even if an earlier security step
+        # (gitleaks/semgrep) failed — the audit findings are useful regardless.
+        if: always() && github.event_name == 'pull_request' && hashFiles('qa-audit-report.md') != ''
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: qa-architect-audit
+          path: qa-audit-report.md
 
   # Step 3: Tests - run if test files exist (development+)
   # Smart skip: Draft PRs skip tests (saves CI costs during WIP)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -340,9 +340,13 @@ jobs:
           set -e
           if command -v pipx >/dev/null 2>&1; then
             pipx install semgrep==1.85.0
+            # semgrep 1.85.0 imports pkg_resources, which setuptools provides but
+            # Python 3.12 no longer bundles — inject setuptools into semgrep's venv
+            # so it runs on the runner's 3.12 (otherwise: ModuleNotFoundError).
+            pipx inject semgrep setuptools
             BIN_DIR="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
           else
-            pip install --user semgrep==1.85.0
+            pip install --user setuptools semgrep==1.85.0
             BIN_DIR="$(python3 -m site --user-base)/bin"
           fi
           echo "Resolved semgrep bin dir: $BIN_DIR"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -330,15 +330,25 @@ jobs:
           esac
 
       - name: Install semgrep CLI for vibe-audit
-        # The installed binary's dir is NOT on PATH for later steps by default, so
-        # export it via $GITHUB_PATH. pipx's bin dir varies by runner
-        # (ubuntu-latest preconfigures PIPX_BIN_DIR=/opt/pipx_bin, NOT ~/.local/bin),
-        # so we PIN it to ~/.local/bin and export that exact path — otherwise the
-        # next step reports "semgrep not installed" even though install succeeded.
+        # Install semgrep, then resolve where the binary actually landed and put
+        # THAT dir on $GITHUB_PATH for the next step. pipx's bin dir varies by
+        # runner (ubuntu-latest preconfigures PIPX_BIN_DIR=/opt/pipx_bin, not
+        # ~/.local/bin), so we don't guess — we ask pipx for its bin dir and
+        # verify `semgrep --version` resolves before continuing. Falls back to
+        # `pip install --user` (~/.local/bin) if pipx is unavailable.
         run: |
-          export PIPX_BIN_DIR="$HOME/.local/bin"
-          pipx install semgrep==1.85.0 || pip install --user semgrep==1.85.0
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          set -e
+          if command -v pipx >/dev/null 2>&1; then
+            pipx install semgrep==1.85.0
+            BIN_DIR="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
+          else
+            pip install --user semgrep==1.85.0
+            BIN_DIR="$(python3 -m site --user-base)/bin"
+          fi
+          echo "Resolved semgrep bin dir: $BIN_DIR"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          # Verify it's actually runnable from that dir (fail loudly if not).
+          "$BIN_DIR/semgrep" --version
 
       - name: QA Architect vibe-code audit
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -338,23 +338,20 @@ jobs:
         # `pip install --user` (~/.local/bin) if pipx is unavailable.
         run: |
           set -e
-          # Use a semgrep that supports the runner's Python 3.12 natively. 1.85.0
-          # imports pkg_resources (removed from py3.12) and crashes; 1.96.0+ does
-          # not. The Docker registry-rules action in the security gate keeps 1.85.0
-          # (it ships its own runtime); only this CLI needs the newer build. Our
-          # rule files are simple pattern matches and validate across both.
+          # Install semgrep into a DEDICATED venv (not pipx, not --user). pipx on
+          # the runner produced a semgrep that crashes with
+          # `ModuleNotFoundError: pkg_resources` on Python 3.12; a clean venv
+          # isolates its deps and works reliably across environments (verified
+          # locally). 1.96.0 supports py3.12 natively. The Docker registry-rules
+          # action in the security gate keeps 1.85.0 (own runtime); only this CLI
+          # needs the newer build. Rule files validate across both versions.
           SEMGREP_CLI_VERSION=1.96.0
-          if command -v pipx >/dev/null 2>&1; then
-            pipx install "semgrep==$SEMGREP_CLI_VERSION"
-            BIN_DIR="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
-          else
-            pip install --user "semgrep==$SEMGREP_CLI_VERSION"
-            BIN_DIR="$(python3 -m site --user-base)/bin"
-          fi
-          echo "Resolved semgrep bin dir: $BIN_DIR"
-          echo "$BIN_DIR" >> "$GITHUB_PATH"
-          # Verify it's actually runnable from that dir (fail loudly if not).
-          "$BIN_DIR/semgrep" --version
+          python3 -m venv "$HOME/.semgrep-venv"
+          "$HOME/.semgrep-venv/bin/pip" install --quiet --upgrade pip setuptools
+          "$HOME/.semgrep-venv/bin/pip" install --quiet "semgrep==$SEMGREP_CLI_VERSION"
+          echo "$HOME/.semgrep-venv/bin" >> "$GITHUB_PATH"
+          # Verify it's actually runnable (fail loudly if not).
+          "$HOME/.semgrep-venv/bin/semgrep" --version
 
       - name: QA Architect vibe-code audit
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -231,36 +231,20 @@ jobs:
               ;;
           esac
 
-          echo "🔍 Checking for vulnerable dependencies..."
-          case "$PACKAGE_MANAGER" in
-            "pnpm") pnpm audit --audit-level=moderate ;;
-            "yarn") yarn audit --level=moderate ;;
-            "bun") bun audit --audit-level=moderate ;;
-            "npm"|*) npm audit --audit-level=moderate ;;
-          esac
-
-      - name: Security audit
+      # ONE blocking dependency-CVE gate. Prod deps only: this tool ships via npx,
+      # so production deps are what consumers download — that's the real "CI green
+      # = clean" line. Dev-tooling CVEs don't reach users and are surfaced
+      # (non-blocking) by the audit-report job instead. (Replaces the previous
+      # three cascading audits — moderate-all, high-all, high-prod.)
+      - name: Production dependency CVE gate
         run: |
           PACKAGE_MANAGER="${{ needs.detect-maturity.outputs.package-manager }}"
-          echo "🔐 Running security audit with $PACKAGE_MANAGER..."
-
-          case "$PACKAGE_MANAGER" in
-            "pnpm") pnpm audit --audit-level high ;;
-            "yarn") yarn audit --level high ;;
-            "bun") bun audit --audit-level high ;;
-            "npm"|*) npm audit --audit-level high ;;
-          esac
-
-      - name: Production dependencies security audit
-        run: |
-          PACKAGE_MANAGER="${{ needs.detect-maturity.outputs.package-manager }}"
-          echo "🔒 Running production-only dependency audit with $PACKAGE_MANAGER..."
-
+          echo "🔒 Auditing production dependencies (high+) with $PACKAGE_MANAGER..."
           case "$PACKAGE_MANAGER" in
             "pnpm") pnpm audit --audit-level high --prod ;;
             "yarn") yarn audit --level high --groups dependencies ;;
             "bun") bun audit --audit-level high --production ;;
-            "npm"|*) npm audit --audit-level high --production ;;
+            "npm"|*) npm audit --audit-level high --omit=dev ;;
           esac
 
       - name: Check for hardcoded secrets
@@ -271,7 +255,7 @@ jobs:
           if [ -f setup.js ]; then
             node setup.js --security-config
           else
-            npx create-qa-architect@latest --security-config
+            npx --yes create-qa-architect@latest --security-config
           fi
 
       - name: Security pattern detection
@@ -294,10 +278,57 @@ jobs:
           SEMGREP_VERSION: '1.85.0'
           SEMGREP_ENABLE_VERSION_CHECK: 'false'
 
-      # QA Architect's own vibe-code audit — the AI-native rules (secrets in
-      # client bundles, unscoped data access, injection) that generic SAST
-      # misses. Report-only for now: posts findings as a PR comment so teams
-      # see them on every PR without breaking builds on pre-existing issues.
+  # Step 2b: Advisory audit report (NON-BLOCKING). Runs in parallel with the
+  # security gate (needs detect-maturity, NOT security) so a gate failure can
+  # never suppress this report. Surfaces qa-architect's own vibe-code audit (the
+  # AI-native rules generic SAST misses) plus a full-dep-tree advisory audit, and
+  # posts them as a sticky PR comment. PR-only: the comment is meaningless on
+  # push/schedule, so this adds no cost to those runs.
+  audit-report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: detect-maturity
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.event_name == 'pull_request' && needs.detect-maturity.outputs.has-deps == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: ${{ needs.detect-maturity.outputs.package-manager }}
+
+      - name: Setup pnpm
+        if: needs.detect-maturity.outputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          version: '8.15.0'
+
+      - name: Setup Bun
+        if: needs.detect-maturity.outputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.0.0'
+
+      - name: Install dependencies
+        run: ${{ needs.detect-maturity.outputs.install-cmd }}
+
+      - name: Advisory full-tree dependency audit (non-blocking)
+        run: |
+          PACKAGE_MANAGER="${{ needs.detect-maturity.outputs.package-manager }}"
+          echo "ℹ️ Advisory audit — all deps incl. dev tooling (does not block)" >> "$GITHUB_STEP_SUMMARY"
+          case "$PACKAGE_MANAGER" in
+            "pnpm") pnpm audit --audit-level=moderate >> "$GITHUB_STEP_SUMMARY" 2>&1 || true ;;
+            "yarn") yarn audit --level=moderate >> "$GITHUB_STEP_SUMMARY" 2>&1 || true ;;
+            "bun") bun audit --audit-level=moderate >> "$GITHUB_STEP_SUMMARY" 2>&1 || true ;;
+            "npm"|*) npm audit --audit-level=moderate >> "$GITHUB_STEP_SUMMARY" 2>&1 || true ;;
+          esac
+
       - name: Install semgrep CLI for vibe-audit
         # pipx installs to ~/.local/bin, which is NOT on PATH for later steps by
         # default — export it via $GITHUB_PATH so the audit step below can find
@@ -316,9 +347,7 @@ jobs:
           fi
 
       - name: Post audit report as PR comment
-        # always() so the report still posts even if an earlier security step
-        # (gitleaks/semgrep) failed — the audit findings are useful regardless.
-        if: always() && github.event_name == 'pull_request' && hashFiles('qa-audit-report.md') != ''
+        if: always() && hashFiles('qa-audit-report.md') != ''
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: qa-architect-audit
@@ -447,14 +476,9 @@ jobs:
       - name: Install dependencies
         run: ${{ needs.detect-maturity.outputs.install-cmd }}
 
-      - name: Configuration security check
-        run: |
-          echo "🔍 Running configuration security validation..."
-          if [ -f setup.js ]; then
-            node setup.js --security-config
-          else
-            npx create-qa-architect@latest --security-config
-          fi
+      # (Secret scanning lives in the `security` gate job, which runs on every
+      # PR/push. It was duplicated here previously — removed to avoid running
+      # gitleaks twice per workflow.)
 
       - name: Documentation validation
         run: |
@@ -564,6 +588,7 @@ jobs:
     needs:
       - detect-maturity
       - security
+      - audit-report
       - tests
       - documentation
     if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -338,15 +338,17 @@ jobs:
         # `pip install --user` (~/.local/bin) if pipx is unavailable.
         run: |
           set -e
+          # Use a semgrep that supports the runner's Python 3.12 natively. 1.85.0
+          # imports pkg_resources (removed from py3.12) and crashes; 1.96.0+ does
+          # not. The Docker registry-rules action in the security gate keeps 1.85.0
+          # (it ships its own runtime); only this CLI needs the newer build. Our
+          # rule files are simple pattern matches and validate across both.
+          SEMGREP_CLI_VERSION=1.96.0
           if command -v pipx >/dev/null 2>&1; then
-            pipx install semgrep==1.85.0
-            # semgrep 1.85.0 imports pkg_resources, which setuptools provides but
-            # Python 3.12 no longer bundles — inject setuptools into semgrep's venv
-            # so it runs on the runner's 3.12 (otherwise: ModuleNotFoundError).
-            pipx inject semgrep setuptools
+            pipx install "semgrep==$SEMGREP_CLI_VERSION"
             BIN_DIR="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
           else
-            pip install --user setuptools semgrep==1.85.0
+            pip install --user "semgrep==$SEMGREP_CLI_VERSION"
             BIN_DIR="$(python3 -m site --user-base)/bin"
           fi
           echo "Resolved semgrep bin dir: $BIN_DIR"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -283,9 +283,13 @@ jobs:
           cache: true
           cache-key: semgrep-security-audit-1.85.0-javascript-1.85.0-${{ env.SEMGREP_VERSION }}
         env:
-          # Use Semgrep app token if available for enhanced features and rate limits
-          # Falls back to GitHub token for basic functionality
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use Semgrep app token ONLY if a real one is configured. Do NOT fall
+          # back to GITHUB_TOKEN: any non-empty SEMGREP_APP_TOKEN puts the action
+          # into "logged in" mode (`semgrep ci`), which refuses the `--config`
+          # rules below ("Cannot run semgrep ci with --config while logged in").
+          # Leaving it empty runs the registry config rules locally — exactly
+          # what we want for PR-time SAST without uploading findings to the app.
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMGREP_VERSION: '1.85.0'
           SEMGREP_ENABLE_VERSION_CHECK: 'false'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -330,10 +330,13 @@ jobs:
           esac
 
       - name: Install semgrep CLI for vibe-audit
-        # pipx installs to ~/.local/bin, which is NOT on PATH for later steps by
-        # default — export it via $GITHUB_PATH so the audit step below can find
-        # the `semgrep` binary. Without this the audit reports "not installed".
+        # The installed binary's dir is NOT on PATH for later steps by default, so
+        # export it via $GITHUB_PATH. pipx's bin dir varies by runner
+        # (ubuntu-latest preconfigures PIPX_BIN_DIR=/opt/pipx_bin, NOT ~/.local/bin),
+        # so we PIN it to ~/.local/bin and export that exact path — otherwise the
+        # next step reports "semgrep not installed" even though install succeeded.
         run: |
+          export PIPX_BIN_DIR="$HOME/.local/bin"
           pipx install semgrep==1.85.0 || pip install --user semgrep==1.85.0
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -299,7 +299,12 @@ jobs:
       # misses. Report-only for now: posts findings as a PR comment so teams
       # see them on every PR without breaking builds on pre-existing issues.
       - name: Install semgrep CLI for vibe-audit
-        run: pipx install semgrep==1.85.0 || pip install semgrep==1.85.0
+        # pipx installs to ~/.local/bin, which is NOT on PATH for later steps by
+        # default — export it via $GITHUB_PATH so the audit step below can find
+        # the `semgrep` binary. Without this the audit reports "not installed".
+        run: |
+          pipx install semgrep==1.85.0 || pip install --user semgrep==1.85.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: QA Architect vibe-code audit
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -336,21 +336,25 @@ jobs:
         # ~/.local/bin), so we don't guess — we ask pipx for its bin dir and
         # verify `semgrep --version` resolves before continuing. Falls back to
         # `pip install --user` (~/.local/bin) if pipx is unavailable.
+        # Best-effort: this is the ADVISORY job. If semgrep won't install, the
+        # vibe-audit degrades to a "SCAN SKIPPED" report (via --no-fail) and the
+        # job still passes — we never block a PR on advisory tooling.
+        continue-on-error: true
         run: |
           set -e
-          # Install semgrep into a DEDICATED venv (not pipx, not --user). pipx on
-          # the runner produced a semgrep that crashes with
-          # `ModuleNotFoundError: pkg_resources` on Python 3.12; a clean venv
-          # isolates its deps and works reliably across environments (verified
-          # locally). 1.96.0 supports py3.12 natively. The Docker registry-rules
-          # action in the security gate keeps 1.85.0 (own runtime); only this CLI
-          # needs the newer build. Rule files validate across both versions.
+          # Install semgrep into a dedicated venv with setuptools<81 PINNED.
+          # Root cause of the recurring crash: semgrep (through 1.96) imports
+          # pkg_resources, which setuptools >=81 no longer ships AND Python 3.12
+          # no longer bundles — so on the 3.12 runner the import fails. Pinning
+          # setuptools<81 restores pkg_resources. The Docker registry-rules action
+          # in the security gate keeps 1.85.0 (its own runtime); only this CLI
+          # needs the venv. (Local dev on py3.11 still bundles pkg_resources, which
+          # masked this — hence verifying --version loudly on the 3.12 runner.)
           SEMGREP_CLI_VERSION=1.96.0
           python3 -m venv "$HOME/.semgrep-venv"
-          "$HOME/.semgrep-venv/bin/pip" install --quiet --upgrade pip setuptools
-          "$HOME/.semgrep-venv/bin/pip" install --quiet "semgrep==$SEMGREP_CLI_VERSION"
+          "$HOME/.semgrep-venv/bin/pip" install --quiet --upgrade pip
+          "$HOME/.semgrep-venv/bin/pip" install --quiet "setuptools<81" "semgrep==$SEMGREP_CLI_VERSION"
           echo "$HOME/.semgrep-venv/bin" >> "$GITHUB_PATH"
-          # Verify it's actually runnable (fail loudly if not).
           "$HOME/.semgrep-venv/bin/semgrep" --version
 
       - name: QA Architect vibe-code audit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -152,6 +152,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: detect-maturity
+    # Least privilege: this job only needs to read the code and post a PR
+    # comment. Scoping the token here means a compromised scan dependency
+    # cannot push commits, alter releases, or touch other repo resources.
+    permissions:
+      contents: read
+      pull-requests: write
     # Security MUST run at PR time, not only monthly — "CI green" has to mean
     # "secret-scanned + SAST-clean". Runs on PRs, direct pushes, the monthly
     # scheduled deep scan, and manual dispatch.
@@ -297,7 +303,7 @@ jobs:
           if [ -f setup.js ]; then
             node setup.js --audit --out qa-audit-report.md --no-fail
           else
-            npx create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
+            npx --yes create-qa-architect@latest --audit --out qa-audit-report.md --no-fail
           fi
 
       - name: Post audit report as PR comment

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ npx create-qa-architect@latest
 | ------------------------------------------------- | ---- | --- |
 | SAST (semgrep — auth, injection, XSS, misconfigs) | ✅   | ✅  |
 | npm CVE audit                                     | ✅   | ✅  |
-| Gitleaks secrets scanning                         | ❌   | ✅  |
+| Gitleaks secret scanning (working tree)           | ✅   | ✅  |
+| Full-history secret scan (`--history-scan`)       | ❌   | ✅  |
+| ESLint security ruleset                           | ❌   | ✅  |
 | Hallucinated package detection                    | ❌   | ✅  |
 | `--fix` Claude Code prompts per finding           | ❌   | ✅  |
 
@@ -283,17 +285,17 @@ Shows estimated GitHub Actions usage and provides optimization recommendations.
 
 ## Tech Stack
 
-| Component         | Technology                                         |
-| ----------------- | -------------------------------------------------- |
-| **Runtime**       | Node.js 20+                                        |
-| **Linting**       | ESLint 9 (flat config)                             |
-| **Formatting**    | Prettier 3                                         |
-| **CSS Linting**   | Stylelint 16                                       |
-| **Git Hooks**     | Husky 9 + lint-staged 15                           |
-| **Python**        | Black, Ruff, mypy, pytest                          |
-| **Shell Scripts** | ShellCheck, syntax validation, permissions checks  |
-| **Performance**   | Lighthouse CI                                      |
-| **Security**      | npm audit (Free), Gitleaks + ESLint security (Pro) |
+| Component         | Technology                                                                         |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| **Runtime**       | Node.js 20+                                                                        |
+| **Linting**       | ESLint 9 (flat config)                                                             |
+| **Formatting**    | Prettier 3                                                                         |
+| **CSS Linting**   | Stylelint 16                                                                       |
+| **Git Hooks**     | Husky 9 + lint-staged 15                                                           |
+| **Python**        | Black, Ruff, mypy, pytest                                                          |
+| **Shell Scripts** | ShellCheck, syntax validation, permissions checks                                  |
+| **Performance**   | Lighthouse CI                                                                      |
+| **Security**      | npm audit + Gitleaks secret scan (Free), full-history scan + ESLint security (Pro) |
 
 ## Getting Started
 

--- a/docs/CI-COST-ANALYSIS.md
+++ b/docs/CI-COST-ANALYSIS.md
@@ -54,7 +54,9 @@ detect-maturity:
 
 ### 2. Minimal Workflow Mode (v5.11.1)
 
-- Security scans: Weekly only (not every push)
+- Security GATE (secret scan + prod-dep CVE + SAST): every PR/push — "CI green" means secret-scanned + SAST-clean
+- Advisory audit report (vibe-audit + full-tree audit, non-blocking): every PR
+- Full-history secret deep scan: monthly (scheduled)
 - Test matrix: Node 22 only (not [20, 22])
 - Path filters: Skip docs-only changes
 - Concurrency: Cancel in-progress runs
@@ -81,7 +83,7 @@ qa-architect supports three workflow modes:
 ### Minimal Mode (Default)
 
 - Single Node.js version (22)
-- Security scans monthly only
+- Security gate (secrets + prod CVE + SAST) on every PR/push; full-history deep scan monthly
 - Path filters enabled
 - Skip Dependabot PRs
 - Concurrency limits
@@ -89,7 +91,7 @@ qa-architect supports three workflow modes:
 ### Standard Mode (`--workflow-standard`)
 
 - Single Node 22 (no matrix), tests restricted to main branch only
-- Security on manual/monthly schedule
+- Security gate on every PR/push; full-history deep scan monthly
 - Full test coverage
 
 ### Comprehensive Mode (`--workflow-comprehensive`)

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -411,6 +411,38 @@ function buildHumanReport(findings, options = {}) {
   return lines.join('\n')
 }
 
+// Report emitted in --no-fail mode when the audit could not actually run
+// (semgrep missing, rule files absent, scan failure). PR-comment-ready so
+// teams see *why* the scan was skipped instead of a silently-green check.
+function buildSkippedReport(result) {
+  const reasons = {
+    semgrep_not_installed:
+      'semgrep is not installed on the runner, so code-pattern scanning was skipped.',
+    no_rules:
+      'Semgrep rule files were not found, so code-pattern scanning was skipped.',
+  }
+  const detail = reasons[result.error] || `audit error: ${result.error}`
+
+  const lines = []
+  lines.push('## QA Architect — Vibe-Code Security Audit')
+  lines.push('')
+  lines.push('**Verdict:** ⏭️ **SCAN SKIPPED**')
+  lines.push('')
+  lines.push(`The vibe-code audit could not run: ${detail}`)
+  lines.push('')
+  lines.push(
+    'Report-only mode (`--no-fail`) is enabled, so this did not fail the build.'
+  )
+  if (result.hint) {
+    lines.push('')
+    lines.push('```')
+    lines.push(String(result.hint).trim())
+    lines.push('```')
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
 function buildMarkdownReport(findings, options = {}) {
   const grouped = groupBySeverity(findings)
   const total = findings.length
@@ -591,14 +623,32 @@ async function handleAudit(options = {}) {
 
   const result = await runAudit(projectPath, auditOptions)
 
-  if (result.error === 'semgrep_not_installed') {
-    console.error('❌ semgrep is not installed.')
-    console.error(result.hint)
-    process.exit(1)
-  }
-
+  // Infrastructure errors (semgrep missing, no rule files, scan failure) mean
+  // the audit could not run — distinct from "ran and found issues". In CI
+  // report-only mode (--no-fail) these MUST NOT break the build: emit a report
+  // explaining the scan was skipped and exit 0. Without --no-fail, surface the
+  // error and exit 1 so a human running it locally knows the scan didn't run.
   if (result.error) {
-    console.error(`❌ Audit error: ${result.error}`)
+    if (result.error === 'semgrep_not_installed') {
+      console.error('❌ semgrep is not installed.')
+      console.error(result.hint)
+    } else if (result.error === 'no_rules') {
+      console.error(`❌ Audit error: ${result.error}`)
+      if (result.hint) console.error(result.hint)
+    } else {
+      console.error(`❌ Audit error: ${result.error}`)
+    }
+
+    if (options.noFail) {
+      const skipReport = buildSkippedReport(result)
+      if (outPath) {
+        fs.writeFileSync(outPath, skipReport, 'utf8')
+        console.log(`✅ Audit report written to ${outPath} (scan skipped)`)
+      }
+      console.log('⏭️  --no-fail set: audit could not run; exiting 0.')
+      process.exit(0)
+    }
+
     process.exit(1)
   }
 
@@ -665,4 +715,5 @@ module.exports = {
   groupBySeverity,
   buildMarkdownReport,
   buildHumanReport,
+  buildSkippedReport,
 }

--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -97,7 +97,7 @@ const FEATURES = deepFreeze({
     frameworkGrouping: false,
     smartTestStrategy: false, // ❌ PRO feature
     typescriptProtection: false, // ❌ PRO feature (moved from FREE)
-    securityScanning: false, // ❌ PRO feature - Gitleaks, ESLint security
+    securityScanning: false, // ❌ PRO - ESLint security ruleset + full-history scan (basic working-tree Gitleaks ships free via the CI gate)
     projectTypeDetection: false,
     customSchedules: false,
     advancedWorkflows: false,
@@ -134,8 +134,9 @@ const FEATURES = deepFreeze({
       '✅ axe-core accessibility testing',
       '✅ Conventional commits (commitlint)',
       '✅ Security audit (semgrep SAST + npm CVEs) — qa-architect --audit',
+      '✅ Gitleaks secret scanning (working tree) in the CI gate',
       '⚠️ Limited: 1 private repo, JS/TS only',
-      '❌ No Gitleaks secrets scanning (Pro)',
+      '❌ No full-history secret scan (--history-scan) or ESLint security ruleset (Pro)',
       '❌ No hallucinated package detection (Pro)',
       '❌ No --fix Claude Code prompts (Pro)',
       '❌ No Smart Test Strategy',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "express": "^5.2.1",
         "helmet": "^8.2.0",
         "js-yaml": "^4.1.0",
-        "markdownlint-cli2": "^0.21.0",
         "ora": "^8.1.1",
         "standardwebhooks": "^1.0.0",
         "tar": "^7.5.7"
@@ -46,6 +45,7 @@
         "knip": "^6.0.1",
         "license-checker": "^25.0.1",
         "lint-staged": "^15.2.10",
+        "markdownlint-cli2": "^0.21.0",
         "prettier": "^3.8.0",
         "size-limit": "^11.0.0",
         "stylelint": "^16.26.1",
@@ -2072,6 +2072,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2085,6 +2086,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2094,6 +2096,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3182,6 +3185,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3259,6 +3263,7 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -3296,12 +3301,14 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3318,6 +3325,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -4157,6 +4165,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4425,6 +4434,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4435,6 +4445,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4445,6 +4456,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5459,6 +5471,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -5513,6 +5526,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5543,6 +5557,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -5714,6 +5729,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6490,6 +6506,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6506,6 +6523,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6591,6 +6609,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6651,6 +6670,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7062,6 +7082,7 @@
       "version": "16.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.0.tgz",
       "integrity": "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -7082,6 +7103,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
       "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7325,6 +7347,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7482,6 +7505,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7492,6 +7516,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
@@ -7553,6 +7578,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7579,6 +7605,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7601,6 +7628,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7613,6 +7641,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7642,6 +7671,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7661,6 +7691,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7910,6 +7941,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonparse": {
@@ -7943,6 +7975,7 @@
       "version": "0.16.28",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
       "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
+      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -7959,6 +7992,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8655,6 +8689,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -9042,6 +9077,7 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -9059,6 +9095,7 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
       "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark": "4.0.2",
@@ -9082,6 +9119,7 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.21.0.tgz",
       "integrity": "sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "globby": "16.1.0",
@@ -9106,6 +9144,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
       "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
@@ -9118,6 +9157,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9130,6 +9170,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
       "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.0",
@@ -9146,6 +9187,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -9195,6 +9237,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -9242,6 +9285,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9268,6 +9312,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9303,6 +9348,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9337,6 +9383,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
       "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -9356,6 +9403,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -9372,6 +9420,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -9392,6 +9441,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -9409,6 +9459,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
       "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/katex": "^0.16.0",
@@ -9428,6 +9479,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9449,6 +9501,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9471,6 +9524,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9491,6 +9545,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9513,6 +9568,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9535,6 +9591,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9555,6 +9612,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9574,6 +9632,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9595,6 +9654,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9615,6 +9675,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9634,6 +9695,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9650,6 +9712,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9666,6 +9729,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9685,6 +9749,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9704,6 +9769,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9725,6 +9791,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9747,6 +9814,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9763,6 +9831,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9779,6 +9848,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -10580,6 +10650,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -10718,6 +10789,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10956,6 +11028,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11041,6 +11114,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11302,6 +11376,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -11462,6 +11537,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11738,6 +11814,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -12530,9 +12607,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -12758,6 +12835,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12937,6 +13015,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unbash": {
@@ -13533,9 +13612,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "knip": "^6.0.1",
     "license-checker": "^25.0.1",
     "lint-staged": "^15.2.10",
+    "markdownlint-cli2": "^0.21.0",
     "prettier": "^3.8.0",
     "size-limit": "^11.0.0",
     "stylelint": "^16.26.1",
@@ -230,7 +231,6 @@
     "express": "^5.2.1",
     "helmet": "^8.2.0",
     "js-yaml": "^4.1.0",
-    "markdownlint-cli2": "^0.21.0",
     "ora": "^8.1.1",
     "standardwebhooks": "^1.0.0",
     "tar": "^7.5.7"

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -15,6 +15,7 @@ const {
   groupBySeverity,
   buildMarkdownReport,
   buildHumanReport,
+  buildSkippedReport,
 } = require('../lib/commands/audit')
 
 let passed = 0
@@ -334,6 +335,40 @@ test('shows count summary', () => {
   assert.ok(report.includes('Total findings: 3'))
   assert.ok(report.includes('Critical: 1'))
   assert.ok(report.includes('Medium:   2'))
+})
+
+// ---------------------------------------------------------------------------
+// buildSkippedReport (--no-fail infrastructure-error path)
+// ---------------------------------------------------------------------------
+
+console.log('\nbuildSkippedReport')
+
+test('explains semgrep-not-installed and marks scan skipped', () => {
+  const report = buildSkippedReport({
+    error: 'semgrep_not_installed',
+    hint: 'install semgrep',
+  })
+  assert.ok(report.includes('SCAN SKIPPED'))
+  assert.ok(report.includes('semgrep is not installed'))
+  assert.ok(report.includes('--no-fail'))
+  assert.ok(report.includes('install semgrep'))
+})
+
+test('explains missing rule files', () => {
+  const report = buildSkippedReport({ error: 'no_rules' })
+  assert.ok(report.includes('SCAN SKIPPED'))
+  assert.ok(report.includes('rule files were not found'))
+})
+
+test('falls back to raw error text for unknown errors', () => {
+  const report = buildSkippedReport({ error: 'timeout' })
+  assert.ok(report.includes('SCAN SKIPPED'))
+  assert.ok(report.includes('timeout'))
+})
+
+test('omits hint code block when no hint provided', () => {
+  const report = buildSkippedReport({ error: 'no_rules' })
+  assert.ok(!report.includes('```'))
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -643,8 +643,8 @@ assert.ok(
   'Workflow should include security job'
 )
 assert.ok(
-  workflowContent.includes('Security audit'),
-  'Workflow should include security audit step'
+  workflowContent.includes('Production dependency CVE gate'),
+  'Workflow should include the production dependency CVE gate step'
 )
 assert.ok(
   workflowContent.includes('gitleaks secret scanning'),

--- a/tests/workflow-tiers.test.js
+++ b/tests/workflow-tiers.test.js
@@ -498,33 +498,34 @@ jobs:
     )
     const workflowContent = fs.readFileSync(workflowPath, 'utf8')
 
-    // Count pnpm setup steps (should be 4: detect-maturity, security, tests, documentation)
-    // Note: core-checks and linting jobs were removed (pre-commit handles lint/format locally)
+    // Count pnpm setup steps (should be 5: detect-maturity, security, audit-report, tests, documentation)
+    // Note: core-checks and linting jobs were removed (pre-commit handles lint/format locally).
+    // audit-report is the advisory job split out from the security gate.
     const pnpmSetupMatches = workflowContent.match(/- name: Setup pnpm/g)
     assert(
-      pnpmSetupMatches && pnpmSetupMatches.length === 4,
-      `Should have 4 pnpm setup steps, found ${pnpmSetupMatches ? pnpmSetupMatches.length : 0}`
+      pnpmSetupMatches && pnpmSetupMatches.length === 5,
+      `Should have 5 pnpm setup steps, found ${pnpmSetupMatches ? pnpmSetupMatches.length : 0}`
     )
 
-    // Count bun setup steps (should also be 4)
+    // Count bun setup steps (should also be 5)
     const bunSetupMatches = workflowContent.match(/- name: Setup Bun/g)
     assert(
-      bunSetupMatches && bunSetupMatches.length === 4,
-      `Should have 4 Bun setup steps, found ${bunSetupMatches ? bunSetupMatches.length : 0}`
+      bunSetupMatches && bunSetupMatches.length === 5,
+      `Should have 5 Bun setup steps, found ${bunSetupMatches ? bunSetupMatches.length : 0}`
     )
 
     // Verify pnpm version format
     const pnpmVersionMatches = workflowContent.match(/version: '8\.15\.0'/g)
     assert(
-      pnpmVersionMatches && pnpmVersionMatches.length === 4,
-      `Should have 4 pnpm version: '8.15.0' entries, found ${pnpmVersionMatches ? pnpmVersionMatches.length : 0}`
+      pnpmVersionMatches && pnpmVersionMatches.length === 5,
+      `Should have 5 pnpm version: '8.15.0' entries, found ${pnpmVersionMatches ? pnpmVersionMatches.length : 0}`
     )
 
     // Verify bun version format
     const bunVersionMatches = workflowContent.match(/bun-version: '1\.0\.0'/g)
     assert(
-      bunVersionMatches && bunVersionMatches.length === 4,
-      `Should have 4 bun-version: '1.0.0' entries, found ${bunVersionMatches ? bunVersionMatches.length : 0}`
+      bunVersionMatches && bunVersionMatches.length === 5,
+      `Should have 5 bun-version: '1.0.0' entries, found ${bunVersionMatches ? bunVersionMatches.length : 0}`
     )
 
     // Verify all pnpm setups are conditional


### PR DESCRIPTION
Supersedes #173 (which got stuck CLOSED after a force-push + close/reopen GitHub quirk; branch and all commits are intact at 585a774).

Makes the security job run at PR time (not just monthly), adds least-privilege permissions, and posts the vibe-audit as a sticky PR comment. Includes two CI fixes found during quality review:
- honor --no-fail on infra errors (semgrep-not-installed no longer hard-fails the report-only PR audit)
- drop GITHUB_TOKEN fallback for SEMGREP_APP_TOKEN (was forcing semgrep-action into logged-in mode that rejects --config)
- put pipx-installed semgrep on $GITHUB_PATH

Reviewed-By: claude-quality
Reviewed-By: codex (status=approve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)